### PR TITLE
[설정] Jacoco 테스트 커버리지 측정 및 자동화(issue#8)

### DIFF
--- a/.github/workflows/code-coverage-and-test-result.yml
+++ b/.github/workflows/code-coverage-and-test-result.yml
@@ -1,0 +1,49 @@
+name: Jacoco Code Coverage & Test Result workflow
+
+permissions:
+    checks: write
+    pull-requests: write
+
+on:
+    push:
+        branches:
+            - 'develop'
+            - 'main'
+    pull_request:
+        branches:
+            - 'develop'
+            - 'main'
+
+jobs:
+    code-coverage:
+        if: ${{ contains(github.event.*.labels.*.name, '테스트') }}
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+            -   name: JDK 11 구성
+                uses: actions/setup-java@v3
+                with:
+                    java-version: '11'
+                    distribution: 'temurin'
+            -   name: Gradle 래퍼 유효성 검사
+                uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+            -   name: Gradle 테스트
+                uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+                with:
+                    arguments: test
+
+            -   name: 테스트 결과 출력
+                uses: EnricoMi/publish-unit-test-result-action@v2
+                if: ${{ always() }}
+                with:
+                    files: |
+                        ./mealkitary-api/build/test-results/**/*.xml
+                        ./mealkitary-domain/build/test-results/**/*.xml
+
+            -   name: Jacoco Coverage 리포트 전송
+                uses: codecov/codecov-action@v3
+                with:
+                    token: ${{ secrets.CODECOV_TOKEN }}
+                    files: ./mealkitary-api/build/reports/jacoco/test/jacocoTestReport.xml,./mealkitary-domain/build/reports/jacoco/test/jacocoTestReport.xml
+                    name: mealkitary-codecov
+                    verbose: true

--- a/.github/workflows/gpt-code-review.yml
+++ b/.github/workflows/gpt-code-review.yml
@@ -9,7 +9,7 @@ on:
     types: [opened, reopened, synchronize]
 
 jobs:
-  test:
+  gpt-code-review:
     if: ${{ contains(github.event.*.labels.*.name, '리뷰') }}
     runs-on: ubuntu-latest
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,8 +61,8 @@ subprojects {
     tasks.jacocoTestReport {
         dependsOn(tasks.test)
         reports {
-            csv.required.set(true)
-            xml.required.set(false)
+            xml.required.set(true)
+            csv.required.set(false)
         }
         finalizedBy(tasks.jacocoTestCoverageVerification)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,14 +31,6 @@ allprojects {
                 jvmTarget = jvmVersion
             }
         }
-
-        withType<BootJar> {
-            enabled = false
-        }
-
-        withType<Jar> {
-            enabled = true
-        }
     }
 
     repositories {
@@ -54,6 +46,12 @@ subprojects {
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
     apply(plugin = "jacoco")
+
+    val jar: Jar by tasks
+    val bootJar: BootJar by tasks
+
+    jar.enabled = true
+    bootJar.enabled = false
 
     jacoco {
         val jacocoVersion: String by properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,29 +2,33 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
-    id("org.springframework.boot") version "2.7.11" apply false
-    id("io.spring.dependency-management") version "1.0.15.RELEASE" apply false
-    id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
-
-    kotlin("jvm") version "1.6.21"
-    kotlin("plugin.spring") version "1.6.21" apply false
-    kotlin("plugin.jpa") version "1.6.21" apply false
+    id("org.springframework.boot") apply false
+    id("io.spring.dependency-management") apply false
+    id("org.jlleitschuh.gradle.ktlint")
+    kotlin("plugin.spring") apply false
+    kotlin("plugin.jpa") apply false
+    kotlin("jvm")
+    jacoco
 }
 
 allprojects {
-    group = "com.mealkitary"
-    version = "0.0.1-SNAPSHOT"
+    val projectGroup: String by project
+    val applicationVersion: String by project
+    val jvmVersion: String by project
+
+    group = projectGroup
+    version = applicationVersion
 
     tasks {
         withType<JavaCompile> {
-            sourceCompatibility = "11"
-            targetCompatibility = "11"
+            sourceCompatibility = jvmVersion
+            targetCompatibility = jvmVersion
         }
 
         withType<KotlinCompile> {
             kotlinOptions {
                 freeCompilerArgs = listOf("-Xjsr305=strict")
-                jvmTarget = "11"
+                jvmTarget = jvmVersion
             }
         }
 
@@ -35,10 +39,6 @@ allprojects {
         withType<Jar> {
             enabled = true
         }
-
-        withType<Test> {
-            useJUnitPlatform()
-        }
     }
 
     repositories {
@@ -47,19 +47,67 @@ allprojects {
 }
 
 subprojects {
-    apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jetbrains.kotlin.plugin.spring")
     apply(plugin = "org.springframework.boot")
     apply(plugin = "io.spring.dependency-management")
+    apply(plugin = "org.jetbrains.kotlin.plugin.jpa")
+    apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
+    apply(plugin = "jacoco")
+
+    jacoco {
+        val jacocoVersion: String by properties
+        toolVersion = jacocoVersion
+    }
+
+    tasks.jacocoTestReport {
+        dependsOn(tasks.test)
+        reports {
+            csv.required.set(true)
+            xml.required.set(false)
+        }
+        finalizedBy(tasks.jacocoTestCoverageVerification)
+    }
+
+    tasks.jacocoTestCoverageVerification {
+        val limitOfLineCoverage: String by properties
+
+        dependsOn(tasks.jacocoTestReport)
+        violationRules {
+            rule {
+                enabled = true
+                element = "CLASS"
+
+                limit {
+                    counter = "LINE"
+                    value = "COVEREDRATIO"
+                    minimum = limitOfLineCoverage.toBigDecimal()
+                }
+
+                excludes = listOf(
+                    "com.mealkitary.*Application*",
+                    "com.mealkitary.common.**"
+                )
+            }
+        }
+    }
+
+    tasks {
+        withType<Test> {
+            useJUnitPlatform()
+            finalizedBy(jacocoTestReport)
+        }
+    }
 
     dependencies {
-        implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-        implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+        val kotestVersion: String by properties
+        val mockkVersion: String by properties
+
         implementation("org.jetbrains.kotlin:kotlin-reflect")
+        implementation("org.springframework.boot:spring-boot-starter-data-jpa")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
-        testImplementation("io.kotest:kotest-runner-junit5:5.4.2")
-        testImplementation("io.kotest:kotest-assertions-core:5.4.2")
-        testImplementation("io.mockk:mockk:1.12.4")
+        testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+        testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+        testImplementation("io.mockk:mockk:$mockkVersion")
     }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+    require_ci_to_pass: yes
+
+comment:
+    layout: "reach,diff,flags,files,footer"
+    behavior: default
+    require_changes: false
+    branches:
+        - develop
+        - main

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,17 @@
+# kotlin
 kotlin.code.style=official
+kotlinVersion=1.6.21
+ktlintVersion=11.0.0
+# spring
+springBootVersion=2.7.11
+springDependencyManagementVersion=1.0.15.RELEASE
+# project
+applicationVersion=0.0.1-SNAPSHOT
+projectGroup=com.mealkitary
+# test
+kotestVersion=5.4.2
+mockkVersion=1.12.4
+jacocoVersion=0.8.7
+limitOfLineCoverage=0.80
+# jvm
+jvmVersion=11

--- a/mealkitary-api/build.gradle.kts
+++ b/mealkitary-api/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 dependencies {
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation(project(":mealkitary-application"))
     implementation(project(":mealkitary-domain"))

--- a/mealkitary-api/build.gradle.kts
+++ b/mealkitary-api/build.gradle.kts
@@ -1,17 +1,15 @@
 import org.springframework.boot.gradle.tasks.bundling.BootJar
 
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = true
+jar.enabled = false
+
 dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation(project(":mealkitary-application"))
     implementation(project(":mealkitary-domain"))
     implementation(project(":mealkitary-infrastructure:adapter-persistence-spring-data-jpa"))
-}
-
-tasks.withType<BootJar> {
-    enabled = true
-}
-
-tasks.withType<Jar> {
-    enabled = false
 }

--- a/mealkitary-domain/build.gradle.kts
+++ b/mealkitary-domain/build.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-    kotlin("plugin.jpa") version "1.6.21"
-}
-
 allOpen {
     annotation("javax.persistence.Entity")
     annotation("javax.persistence.Embeddable")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,27 @@
 rootProject.name = "mealkitary"
+
 include(
     "mealkitary-api",
     "mealkitary-application",
     "mealkitary-domain",
     "mealkitary-infrastructure:adapter-persistence-spring-data-jpa"
 )
+
+pluginManagement {
+    val kotlinVersion: String by settings
+    val ktlintVersion: String by settings
+    val springBootVersion: String by settings
+    val springDependencyManagementVersion: String by settings
+
+    resolutionStrategy {
+        eachPlugin {
+            when (requested.id.id) {
+                "org.springframework.boot" -> useVersion(springBootVersion)
+                "io.spring.dependency-management" -> useVersion(springDependencyManagementVersion)
+                "org.jetbrains.kotlin.jvm", "org.jetbrains.kotlin.plugin.spring",
+                "org.jetbrains.kotlin.plugin.jpa" -> useVersion(kotlinVersion)
+                "org.jlleitschuh.gradle.ktlint" -> useVersion(ktlintVersion)
+            }
+        }
+    }
+}


### PR DESCRIPTION
**구현 요약**

Jacoco로 테스트 커버리지를 측정하고, 이를 워크 플로우로 브랜치에 PR이 생길때마다 수행하도록 자동화하도록 구현했습니다.
세부 구현 내용은 아래와 같습니다.
- jacoco 설정
- gradle 의존성 버전 관리
- bootJar 빌드 에러 해결
- github action workflow로 `테스트` 라벨이 붙을 경우,  jacoco 결과를 codecov에 업로드하고, 테스트 결과를 comment로 남김



**연관 이슈**
#8 