### PR TITLE
[기능 구현] 가게 모델 조회 기능 구현(issue#15)

### DIFF
--- a/.github/workflows/code-coverage-and-test-result.yml
+++ b/.github/workflows/code-coverage-and-test-result.yml
@@ -39,11 +39,13 @@ jobs:
                     files: |
                         ./mealkitary-api/build/test-results/**/*.xml
                         ./mealkitary-domain/build/test-results/**/*.xml
+                        ./mealkitary-application/build/test-results/**/*.xml
+                        ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/test-results/**/*.xml
 
             -   name: Jacoco Coverage 리포트 전송
                 uses: codecov/codecov-action@v3
                 with:
                     token: ${{ secrets.CODECOV_TOKEN }}
-                    files: ./mealkitary-api/build/reports/jacoco/test/jacocoTestReport.xml,./mealkitary-domain/build/reports/jacoco/test/jacocoTestReport.xml
+                    files: ./mealkitary-api/build/reports/jacoco/test/jacocoTestReport.xml,./mealkitary-domain/build/reports/jacoco/test/jacocoTestReport.xml,./mealkitary-application/build/reports/jacoco/test/jacocoTestReport.xml,./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml
                     name: mealkitary-codecov
                     verbose: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,7 @@ subprojects {
 
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+        implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
         testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,8 @@ subprojects {
 
                 excludes = listOf(
                     "com.mealkitary.*Application*",
-                    "com.mealkitary.common.constants.**"
+                    "com.mealkitary.common.constants.**",
+                    "com.mealkitary.application.shop.port.input.**"
                 )
             }
         }
@@ -100,6 +101,7 @@ subprojects {
     dependencies {
         val kotestVersion: String by properties
         val mockkVersion: String by properties
+        val springmockkVersion: String by properties
 
         implementation("org.jetbrains.kotlin:kotlin-reflect")
         implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -107,6 +109,8 @@ subprojects {
         testImplementation("org.springframework.boot:spring-boot-starter-test")
         testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
         testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+        testImplementation("io.kotest:kotest-extensions-spring:$kotestVersion")
+        testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
         testImplementation("io.mockk:mockk:$mockkVersion")
     }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,40 +1,5 @@
 codecov:
     require_ci_to_pass: yes
-    status:
-        project: off
-        patch: off
-
-flag_management:
-    individual_flags:
-        -   name: mealkitary-api-integration
-            paths:
-                - mealkitary-api/
-            statuses:
-                -   type: project
-                    target: auto
-                    threshold: 50%
-
-        -   name: mealkitary-application-unit
-            paths:
-                - mealkitary-application/
-            statuses:
-                -   type: project
-                    target: auto
-                    threshold: 50%
-        -   name: mealkitary-domain-unit
-            paths:
-                - mealkitary-domain/
-            statuses:
-                -   type: project
-                    target: auto
-                    threshold: 50%
-        -   name: mealkitary-infrastructure-integration
-            paths:
-                - mealkitary-infrastructure/
-            statuses:
-                -   type: project
-                    target: auto
-                    threshold: 50%
 
 comment:
     layout: "reach,diff,flags,files,footer"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,11 +5,16 @@ comment:
     layout: "reach,diff,flags,files,footer"
     behavior: default
     require_changes: false
+    require_base: yes
+    require_head: yes
     branches:
         - develop
         - main
 
-github_checks: false
 coverage:
     status:
         patch: false
+        project:
+            default:
+                target: auto
+                threshold: 70%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,40 @@
 codecov:
     require_ci_to_pass: yes
+    status:
+        project: off
+        patch: off
+
+flag_management:
+    individual_flags:
+        -   name: mealkitary-api-integration
+            paths:
+                - mealkitary-api/
+            statuses:
+                -   type: project
+                    target: auto
+                    threshold: 50%
+
+        -   name: mealkitary-application-unit
+            paths:
+                - mealkitary-application/
+            statuses:
+                -   type: project
+                    target: auto
+                    threshold: 50%
+        -   name: mealkitary-domain-unit
+            paths:
+                - mealkitary-domain/
+            statuses:
+                -   type: project
+                    target: auto
+                    threshold: 50%
+        -   name: mealkitary-infrastructure-integration
+            paths:
+                - mealkitary-infrastructure/
+            statuses:
+                -   type: project
+                    target: auto
+                    threshold: 50%
 
 comment:
     layout: "reach,diff,flags,files,footer"

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,8 @@ comment:
     branches:
         - develop
         - main
+
+github_checks: false
+coverage:
+    status:
+        patch: false

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,10 @@ springDependencyManagementVersion=1.0.15.RELEASE
 applicationVersion=0.0.1-SNAPSHOT
 projectGroup=com.mealkitary
 # test
-kotestVersion=5.4.2
+kotestVersion=4.4.3
 mockkVersion=1.12.4
 jacocoVersion=0.8.7
-limitOfLineCoverage=0.80
+limitOfLineCoverage=0.70
+springmockkVersion=3.0.1
 # jvm
 jvmVersion=11

--- a/mealkitary-api/build.gradle.kts
+++ b/mealkitary-api/build.gradle.kts
@@ -7,7 +7,6 @@ bootJar.enabled = true
 jar.enabled = false
 
 dependencies {
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation(project(":mealkitary-application"))
     implementation(project(":mealkitary-domain"))

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetProductController.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetProductController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 class GetProductController(
     private val getProductQuery: GetProductQuery
 ) {
+
     @GetMapping("/{shopId}/products")
     fun getAllProductOfShop(@PathVariable("shopId") shopId: Long) =
         ResponseEntity.ok(getProductQuery.loadAllProductByShopId(shopId))

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetProductController.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetProductController.kt
@@ -1,0 +1,18 @@
+package com.mealkitary.shop.adapter.input.web
+
+import com.mealkitary.shop.application.port.input.GetProductQuery
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/shops")
+class GetProductController(
+    private val getProductQuery: GetProductQuery
+) {
+    @GetMapping("/{shopId}/products")
+    fun getAllProductOfShop(@PathVariable("shopId") shopId: Long) =
+        ResponseEntity.ok(getProductQuery.loadAllProductByShopId(shopId))
+}

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetReservableTimeController.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetReservableTimeController.kt
@@ -1,0 +1,18 @@
+package com.mealkitary.shop.adapter.input.web
+
+import com.mealkitary.shop.application.port.input.GetReservableTimeQuery
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/shops")
+class GetReservableTimeController(
+    private val getReservableTimeQuery: GetReservableTimeQuery
+) {
+    @GetMapping("/{shopId}/reservable-time")
+    fun getAllReservableTimeOfShop(@PathVariable("shopId") shopId: Long) =
+        ResponseEntity.ok(getReservableTimeQuery.loadAllReservableTimeByShopId(shopId))
+}

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetReservableTimeController.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetReservableTimeController.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 class GetReservableTimeController(
     private val getReservableTimeQuery: GetReservableTimeQuery
 ) {
+
     @GetMapping("/{shopId}/reservable-time")
     fun getAllReservableTimeOfShop(@PathVariable("shopId") shopId: Long) =
         ResponseEntity.ok(getReservableTimeQuery.loadAllReservableTimeByShopId(shopId))

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetShopController.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetShopController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 class GetShopController(
     private val getShopQuery: GetShopQuery
 ) {
+
     @GetMapping("/")
     fun getAllShop() = ResponseEntity.ok(getShopQuery.loadAllShop())
 }

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetShopController.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/adapter/input/web/GetShopController.kt
@@ -1,0 +1,16 @@
+package com.mealkitary.shop.adapter.input.web
+
+import com.mealkitary.shop.application.port.input.GetShopQuery
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/shops")
+class GetShopController(
+    private val getShopQuery: GetShopQuery
+) {
+    @GetMapping("/")
+    fun getAllShop() = ResponseEntity.ok(getShopQuery.loadAllShop())
+}

--- a/mealkitary-api/src/test/kotlin/com/mealkitary/shop/adapter/input/web/GetProductControllerTest.kt
+++ b/mealkitary-api/src/test/kotlin/com/mealkitary/shop/adapter/input/web/GetProductControllerTest.kt
@@ -1,0 +1,41 @@
+package com.mealkitary.shop.adapter.input.web
+
+import com.mealkitary.shop.application.port.input.GetProductQuery
+import com.mealkitary.shop.application.port.input.ProductResponse
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.mockk.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [GetProductController::class])
+class GetProductControllerTest : AnnotationSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockkBean
+    private lateinit var getProductQuery: GetProductQuery
+
+    @Test
+    fun `api integration test - getAllProductOfShopTest`() {
+        every { getProductQuery.loadAllProductByShopId(1L) }.answers {
+            listOf(ProductResponse(1L, "부대찌개", 15000))
+        }
+
+        mvc.perform(MockMvcRequestBuilders.get("/shops/1/products"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+        verify { getProductQuery.loadAllProductByShopId(1L) }
+    }
+}

--- a/mealkitary-api/src/test/kotlin/com/mealkitary/shop/adapter/input/web/GetReservableTimeControllerTest.kt
+++ b/mealkitary-api/src/test/kotlin/com/mealkitary/shop/adapter/input/web/GetReservableTimeControllerTest.kt
@@ -1,0 +1,40 @@
+package com.mealkitary.shop.adapter.input.web
+
+import com.mealkitary.shop.application.port.input.GetReservableTimeQuery
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import io.mockk.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalTime
+
+@WebMvcTest(controllers = [GetReservableTimeController::class])
+class GetReservableTimeControllerTest : AnnotationSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockkBean
+    private lateinit var getReservableTimeQuery: GetReservableTimeQuery
+
+    @Test
+    fun `api integration test - getAllReservableTimeOfShopTest`() {
+        every { getReservableTimeQuery.loadAllReservableTimeByShopId(1L) }.answers {
+            listOf(LocalTime.of(6, 30))
+        }
+        mvc.perform(get("/shops/1/reservable-time"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+
+        verify { getReservableTimeQuery.loadAllReservableTimeByShopId(1L) }
+    }
+}

--- a/mealkitary-api/src/test/kotlin/com/mealkitary/shop/adapter/input/web/GetShopControllerTest.kt
+++ b/mealkitary-api/src/test/kotlin/com/mealkitary/shop/adapter/input/web/GetShopControllerTest.kt
@@ -1,0 +1,37 @@
+package com.mealkitary.shop.adapter.input.web
+
+import com.mealkitary.shop.application.port.input.GetShopQuery
+import com.mealkitary.shop.application.port.input.ShopResponse
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(controllers = [GetShopController::class])
+class GetShopControllerTest : AnnotationSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @MockkBean
+    private lateinit var getShopQuery: GetShopQuery
+
+    @Test
+    fun `api integration test - getAllShopTest`() {
+        every { getShopQuery.loadAllShop() }.answers {
+            listOf(ShopResponse(1L, "집밥뚝딱"))
+        }
+        mvc.perform(get("/shops/"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+    }
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetProductQuery.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetProductQuery.kt
@@ -1,0 +1,6 @@
+package com.mealkitary.shop.application.port.input
+
+interface GetProductQuery {
+
+    fun loadAllProductByShopId(shopId: Long): List<ProductResponse>
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetReservableTimeQuery.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetReservableTimeQuery.kt
@@ -1,0 +1,7 @@
+package com.mealkitary.shop.application.port.input
+
+import java.time.LocalTime
+
+interface GetReservableTimeQuery {
+    fun loadAllReservableTimeByShopId(shopId: Long): List<LocalTime>
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetReservableTimeQuery.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetReservableTimeQuery.kt
@@ -3,5 +3,6 @@ package com.mealkitary.shop.application.port.input
 import java.time.LocalTime
 
 interface GetReservableTimeQuery {
+
     fun loadAllReservableTimeByShopId(shopId: Long): List<LocalTime>
 }

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetShopQuery.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/GetShopQuery.kt
@@ -1,0 +1,6 @@
+package com.mealkitary.shop.application.port.input
+
+interface GetShopQuery {
+
+    fun loadAllShop(): List<ShopResponse>
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/ProductResponse.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/ProductResponse.kt
@@ -1,0 +1,3 @@
+package com.mealkitary.shop.application.port.input
+
+data class ProductResponse(val id: Long, val name: String, val price: Int)

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/ShopResponse.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/ShopResponse.kt
@@ -1,0 +1,3 @@
+package com.mealkitary.shop.application.port.input
+
+data class ShopResponse(val id: Long?, val title: String)

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/output/LoadProductPort.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/output/LoadProductPort.kt
@@ -1,0 +1,8 @@
+package com.mealkitary.shop.application.port.output
+
+import com.mealkitary.shop.domain.product.Product
+
+interface LoadProductPort {
+
+    fun loadAllProductByShopId(shopId: Long): List<Product>
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/output/LoadReservableTimePort.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/output/LoadReservableTimePort.kt
@@ -1,0 +1,8 @@
+package com.mealkitary.shop.application.port.output
+
+import java.time.LocalTime
+
+interface LoadReservableTimePort {
+
+    fun loadAllReservableTimeByShopId(shopId: Long): List<LocalTime>
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/output/LoadShopPort.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/output/LoadShopPort.kt
@@ -1,0 +1,8 @@
+package com.mealkitary.shop.application.port.output
+
+import com.mealkitary.shop.domain.shop.Shop
+
+interface LoadShopPort {
+
+    fun loadAllShop(): List<Shop>
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/GetProductService.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/GetProductService.kt
@@ -1,0 +1,17 @@
+package com.mealkitary.shop.application.service
+
+import com.mealkitary.shop.application.port.input.GetProductQuery
+import com.mealkitary.shop.application.port.input.ProductResponse
+import com.mealkitary.shop.application.port.output.LoadProductPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GetProductService(
+    private val loadProductPort: LoadProductPort
+) : GetProductQuery {
+
+    override fun loadAllProductByShopId(shopId: Long) = loadProductPort.loadAllProductByShopId(shopId)
+        .map { ProductResponse(it.id.id, it.name, it.price.value) }
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/GetReservableTimeService.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/GetReservableTimeService.kt
@@ -1,0 +1,16 @@
+package com.mealkitary.shop.application.service
+
+import com.mealkitary.shop.application.port.input.GetReservableTimeQuery
+import com.mealkitary.shop.application.port.output.LoadReservableTimePort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GetReservableTimeService(
+    private val loadReservableTimePort: LoadReservableTimePort
+) : GetReservableTimeQuery {
+
+    override fun loadAllReservableTimeByShopId(shopId: Long) =
+        loadReservableTimePort.loadAllReservableTimeByShopId(shopId)
+}

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/GetShopService.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/GetShopService.kt
@@ -1,0 +1,16 @@
+package com.mealkitary.shop.application.service
+
+import com.mealkitary.shop.application.port.input.GetShopQuery
+import com.mealkitary.shop.application.port.input.ShopResponse
+import com.mealkitary.shop.application.port.output.LoadShopPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GetShopService(
+    private val loadShopPort: LoadShopPort
+) : GetShopQuery {
+
+    override fun loadAllShop() = loadShopPort.loadAllShop().map { ShopResponse(it.id, it.title) }
+}

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetProductServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetProductServiceTest.kt
@@ -11,6 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 
 class GetProductServiceTest : AnnotationSpec() {
+
     private val loadProductPort = mockk<LoadProductPort>()
     private val getProductService = GetProductService(loadProductPort)
 

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetProductServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetProductServiceTest.kt
@@ -1,0 +1,26 @@
+package com.mealkitary.shop.application.service
+
+import com.mealkitary.common.model.Money
+import com.mealkitary.shop.application.port.input.ProductResponse
+import com.mealkitary.shop.application.port.output.LoadProductPort
+import com.mealkitary.shop.domain.product.Product
+import com.mealkitary.shop.domain.product.ProductId
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class GetProductServiceTest : AnnotationSpec() {
+    private val loadProductPort = mockk<LoadProductPort>()
+    private val getProductService = GetProductService(loadProductPort)
+
+    @Test
+    fun `service unit test - 가게 ID에 해당하는 가게의 상품 목록을 조회한다`() {
+        every { loadProductPort.loadAllProductByShopId(1L) } answers {
+            listOf(Product(ProductId(1L), "부대찌개", Money.of(15000)))
+        }
+        val actual = getProductService.loadAllProductByShopId(1L)
+        val expected = listOf(ProductResponse(1L, "부대찌개", 15000))
+        actual shouldBe expected
+    }
+}

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetReservableTimeServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetReservableTimeServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import java.time.LocalTime
 
 class GetReservableTimeServiceTest : AnnotationSpec() {
+
     private val loadReservableTimePort = mockk<LoadReservableTimePort>()
     private val getReservableTimeService = GetReservableTimeService(loadReservableTimePort)
 

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetReservableTimeServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetReservableTimeServiceTest.kt
@@ -1,0 +1,30 @@
+package com.mealkitary.shop.application.service
+
+import com.mealkitary.shop.application.port.output.LoadReservableTimePort
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalTime
+
+class GetReservableTimeServiceTest : AnnotationSpec() {
+    private val loadReservableTimePort = mockk<LoadReservableTimePort>()
+    private val getReservableTimeService = GetReservableTimeService(loadReservableTimePort)
+
+    @Test
+    fun `service unit test - 가게 ID에 해당하는 가게의 모든 예약 가능 시간을 조회한다`() {
+        every { loadReservableTimePort.loadAllReservableTimeByShopId(1L) } answers {
+            listOf(
+                LocalTime.of(6, 30),
+                LocalTime.of(18, 30)
+            )
+        }
+        val actual = getReservableTimeService.loadAllReservableTimeByShopId(1L)
+        val expected = listOf(
+            LocalTime.of(6, 30),
+            LocalTime.of(18, 30)
+        )
+        actual shouldBe expected
+        actual.size shouldBe 2
+    }
+}

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
@@ -1,0 +1,25 @@
+package com.mealkitary.shop.application.service
+
+import com.mealkitary.shop.application.port.input.ShopResponse
+import com.mealkitary.shop.application.port.output.LoadShopPort
+import com.mealkitary.shop.domain.shop.Shop
+import com.mealkitary.shop.domain.shop.ShopStatus
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class GetShopServiceTest : AnnotationSpec() {
+    private val loadShopPort = mockk<LoadShopPort>()
+    private val getShopService = GetShopService(loadShopPort)
+
+    @Test
+    fun `service unit test - 모든 가게를 조회한다`() {
+        every { loadShopPort.loadAllShop() } answers {
+            listOf(Shop("집밥뚝딱", ShopStatus.VALID, mutableListOf(), mutableListOf()))
+        }
+        val actual = getShopService.loadAllShop()
+        val expected = ShopResponse(null, "집밥뚝딱")
+        actual shouldBe listOf(expected)
+    }
+}

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 
 class GetShopServiceTest : AnnotationSpec() {
+
     private val loadShopPort = mockk<LoadShopPort>()
     private val getShopService = GetShopService(loadShopPort)
 

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/common/model/Money.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/common/model/Money.kt
@@ -1,6 +1,13 @@
 package com.mealkitary.common.model
 
-data class Money private constructor(val value: Int) {
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+data class Money private constructor(
+    @Column(name = "price")
+    val value: Int
+) {
 
     operator fun times(target: Int): Money {
         return of(value * target)
@@ -23,4 +30,3 @@ data class Money private constructor(val value: Int) {
         }
     }
 }
-

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/reservation/domain/Reservation.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/reservation/domain/Reservation.kt
@@ -20,6 +20,7 @@ class Reservation private constructor(
     private val reserveAt: LocalDateTime,
     private var reservationStatus: ReservationStatus = ReservationStatus.NONE
 ) {
+
     fun calculateTotalPrice(): Money {
         checkNotPaid()
         return lineItems.map { it.calculateEachItemTotalPrice() }

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/reservation/domain/ReservationLineItem.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/reservation/domain/ReservationLineItem.kt
@@ -11,6 +11,7 @@ class ReservationLineItem private constructor(
     private val price: Money,
     private val count: Int
 ) {
+
     fun mapToProduct(): Product {
         return Product(
             this.itemId,

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/reservation/domain/ReservationStatus.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/reservation/domain/ReservationStatus.kt
@@ -1,6 +1,7 @@
 package com.mealkitary.reservation.domain
 
 enum class ReservationStatus {
+
     NONE,
     NOTPAID,
     PAID,

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/product/Product.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/product/Product.kt
@@ -1,12 +1,27 @@
 package com.mealkitary.shop.domain.product
 
 import com.mealkitary.common.model.Money
+import javax.persistence.Embedded
+import javax.persistence.EmbeddedId
+import javax.persistence.Entity
 
+@Entity
 class Product(
-    private val id: ProductId,
-    private val name: String,
-    private val price: Money
+    id: ProductId,
+    name: String,
+    price: Money
 ) {
+    @EmbeddedId
+    var id: ProductId = id
+        protected set
+
+    var name: String = name
+        protected set
+
+    @Embedded
+    var price: Money = price
+        protected set
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/product/Product.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/product/Product.kt
@@ -11,6 +11,7 @@ class Product(
     name: String,
     price: Money
 ) {
+
     @EmbeddedId
     var id: ProductId = id
         protected set

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/product/ProductId.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/product/ProductId.kt
@@ -1,6 +1,11 @@
 package com.mealkitary.shop.domain.product
 
-class ProductId(val id: Long) {
+import java.io.Serializable
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class ProductId(@Column(name = "product_id") var id: Long) : Serializable {
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
@@ -5,6 +5,8 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 class Shop(
+    private val id: Long,
+    private val title: String,
     private val status: ShopStatus,
     private val reservableTimes: List<LocalTime>,
     private val products: List<Product>

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
@@ -25,6 +25,7 @@ class Shop(
     reservableTimes: MutableList<LocalTime>,
     products: MutableList<Product>
 ) {
+
     init {
         checkShopName(title)
     }

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
@@ -1,5 +1,6 @@
 package com.mealkitary.shop.domain.shop
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.mealkitary.shop.domain.product.Product
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -48,6 +49,7 @@ class Shop(
         joinColumns = [JoinColumn(name = "shop_id")]
     )
     @Column(name = "reservable_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
     var reservableTimes: MutableList<LocalTime> = reservableTimes
         protected set
 

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
@@ -1,6 +1,5 @@
 package com.mealkitary.shop.domain.shop
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import com.mealkitary.shop.domain.product.Product
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -49,7 +48,6 @@ class Shop(
         joinColumns = [JoinColumn(name = "shop_id")]
     )
     @Column(name = "reservable_time")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
     var reservableTimes: MutableList<LocalTime> = reservableTimes
         protected set
 
@@ -66,7 +64,7 @@ class Shop(
 
     fun checkReservableShop() {
         if (status.isInvalidStatus()) {
-            throw IllegalArgumentException("유효하지 않은 가게입니다.")
+            throw IllegalStateException("유효하지 않은 가게입니다.")
         }
     }
 

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
@@ -3,14 +3,65 @@ package com.mealkitary.shop.domain.shop
 import com.mealkitary.shop.domain.product.Product
 import java.time.LocalDateTime
 import java.time.LocalTime
+import javax.persistence.CascadeType
+import javax.persistence.CollectionTable
+import javax.persistence.Column
+import javax.persistence.ElementCollection
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.JoinColumn
+import javax.persistence.OneToMany
+import javax.persistence.Table
 
+@Entity
+@Table(name = "shop")
 class Shop(
-    private val id: Long,
-    private val title: String,
-    private val status: ShopStatus,
-    private val reservableTimes: List<LocalTime>,
-    private val products: List<Product>
+    title: String,
+    status: ShopStatus,
+    reservableTimes: MutableList<LocalTime>,
+    products: MutableList<Product>
 ) {
+    init {
+        checkShopName(title)
+    }
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "shop_id")
+    var id: Long? = null
+        protected set
+
+    var title: String = title
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    var status: ShopStatus = status
+        protected set
+
+    @ElementCollection
+    @CollectionTable(
+        name = "reservable_time",
+        joinColumns = [JoinColumn(name = "shop_id")]
+    )
+    @Column(name = "reservable_time")
+    var reservableTimes: MutableList<LocalTime> = reservableTimes
+        protected set
+
+    @OneToMany(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "shop_id")
+    var products: MutableList<Product> = products
+        protected set
+
+    private fun checkShopName(title: String) {
+        if (title.isBlank()) {
+            throw IllegalArgumentException("가게 이름을 입력해주세요.")
+        }
+    }
+
     fun checkReservableShop() {
         if (status.isInvalidStatus()) {
             throw IllegalArgumentException("유효하지 않은 가게입니다.")

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/ShopStatus.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/ShopStatus.kt
@@ -1,6 +1,7 @@
 package com.mealkitary.shop.domain.shop
 
 enum class ShopStatus {
+
     INVALID,
     VALID;
 

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/common/data/ShopTestData.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/common/data/ShopTestData.kt
@@ -9,7 +9,6 @@ import java.time.LocalTime
 class ShopTestData {
 
     class ShopBuilder(
-        private var id: Long = 1L,
         private var title: String = "집밥뚝딱 안양점",
         private var shopStatus: ShopStatus = ShopStatus.VALID,
         private var reservableTimes: List<LocalTime> = listOf(
@@ -22,11 +21,6 @@ class ShopTestData {
             defaultProduct().withId(2L).withName("닭볶음탕").build()
         )
     ) {
-
-        fun withId(id: Long): ShopBuilder {
-            this.id = id
-            return this
-        }
 
         fun withTitle(title: String): ShopBuilder {
             this.title = title
@@ -50,11 +44,10 @@ class ShopTestData {
 
         fun build(): Shop {
             return Shop(
-                this.id,
                 this.title,
                 this.shopStatus,
-                this.reservableTimes,
-                this.products
+                this.reservableTimes.toMutableList(),
+                this.products.toMutableList()
             )
         }
     }

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/common/data/ShopTestData.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/common/data/ShopTestData.kt
@@ -9,6 +9,8 @@ import java.time.LocalTime
 class ShopTestData {
 
     class ShopBuilder(
+        private var id: Long = 1L,
+        private var title: String = "집밥뚝딱 안양점",
         private var shopStatus: ShopStatus = ShopStatus.VALID,
         private var reservableTimes: List<LocalTime> = listOf(
             LocalTime.of(9, 0),
@@ -20,6 +22,16 @@ class ShopTestData {
             defaultProduct().withId(2L).withName("닭볶음탕").build()
         )
     ) {
+
+        fun withId(id: Long): ShopBuilder {
+            this.id = id
+            return this
+        }
+
+        fun withTitle(title: String): ShopBuilder {
+            this.title = title
+            return this
+        }
 
         fun withReservableTimes(vararg times: LocalTime): ShopBuilder {
             this.reservableTimes = times.toList()
@@ -38,6 +50,8 @@ class ShopTestData {
 
         fun build(): Shop {
             return Shop(
+                this.id,
+                this.title,
                 this.shopStatus,
                 this.reservableTimes,
                 this.products

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/reservation/domain/ReservationTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/reservation/domain/ReservationTest.kt
@@ -18,7 +18,7 @@ import java.time.LocalTime
 
 private const val CHANGE_RESERVATION_STATUS_METHOD_NAME = "changeReservationStatus"
 
-internal class ReservationTest : AnnotationSpec() {
+class ReservationTest : AnnotationSpec() {
 
     @Test
     fun `예약 상품이 하나도 존재하지 않는다면 예외를 발생한다`() {
@@ -50,7 +50,7 @@ internal class ReservationTest : AnnotationSpec() {
     @Test
     fun `예약 하려는 가게가 정상 영업 중이 아니라면 예외를 발생한다`() {
         val invalidShop = defaultShop().withStatus(ShopStatus.INVALID).build()
-        shouldThrow<IllegalArgumentException> {
+        shouldThrow<IllegalStateException> {
             val sut = defaultReservation().withShop(invalidShop).build()
             sut.reserve()
         } shouldHaveMessage "유효하지 않은 가게입니다."

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/product/ProductTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/product/ProductTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 
-internal class ProductTest : AnnotationSpec() {
+class ProductTest : AnnotationSpec() {
 
     @Test
     fun `id, 이름, 가격이 같다면 동등하다`() {

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopTest.kt
@@ -7,7 +7,24 @@ import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.throwable.shouldHaveMessage
 
-internal class ShopTest : AnnotationSpec() {
+class ShopTest : AnnotationSpec() {
+
+    @Test
+    fun `유효하지 않은 가게라면 예외를 발생한다`() {
+        val sut = defaultShop().withStatus(ShopStatus.INVALID)
+            .build()
+        shouldThrow<IllegalStateException> {
+            sut.checkReservableShop()
+        } shouldHaveMessage "유효하지 않은 가게입니다."
+    }
+
+    @Test
+    fun `유효한 가게라면 검사에 통과한다`() {
+        val sut = defaultShop().withStatus(ShopStatus.VALID)
+            .build()
+
+        sut.checkReservableShop()
+    }
 
     @Test
     fun `검증하려는 상품이 존재하지 않는다면 예외를 발생한다`() {

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopTest.kt
@@ -4,6 +4,7 @@ import com.mealkitary.common.data.ProductTestData.Companion.defaultProduct
 import com.mealkitary.common.data.ShopTestData.Companion.defaultShop
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.inspectors.forAll
 import io.kotest.matchers.throwable.shouldHaveMessage
 
 internal class ShopTest : AnnotationSpec() {
@@ -40,6 +41,23 @@ internal class ShopTest : AnnotationSpec() {
             .build()
 
         sut.checkItem(product)
+    }
+
+    @Test
+    fun `가게 이름이 빈 문자열일 경우 예외를 발생한다`() {
+        shouldThrow<IllegalArgumentException> {
+            defaultShop().withTitle("").build()
+        } shouldHaveMessage "가게 이름을 입력해주세요."
+    }
+
+    @Test
+    fun `가게 이름이 공백으로만 이루어져 있을 경우, 예외를 발생한다`() {
+        val params = listOf(" ", "  ", "   ", "\n", "\t")
+        params.forAll {
+            shouldThrow<IllegalArgumentException> {
+                defaultShop().withTitle(it).build()
+            } shouldHaveMessage "가게 이름을 입력해주세요."
+        }
     }
 
     private fun productWithIdAndName(id: Long, name: String) = defaultProduct()

--- a/mealkitary-infrastructure/adapter-persistence-in-memory/build.gradle.kts
+++ b/mealkitary-infrastructure/adapter-persistence-in-memory/build.gradle.kts
@@ -1,4 +1,0 @@
-dependencies {
-    implementation(project(":mealkitary-domain"))
-    implementation(project(":mealkitary-application"))
-}

--- a/mealkitary-infrastructure/adapter-persistence-in-memory/build.gradle.kts
+++ b/mealkitary-infrastructure/adapter-persistence-in-memory/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+    implementation(project(":mealkitary-domain"))
+    implementation(project(":mealkitary-application"))
+}

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/kotlin/com/mealkitary/shop/adapter/output/persistence/ShopRepository.kt
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/kotlin/com/mealkitary/shop/adapter/output/persistence/ShopRepository.kt
@@ -1,0 +1,14 @@
+package com.mealkitary.shop.adapter.output.persistence
+
+import com.mealkitary.shop.domain.shop.Shop
+import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ShopRepository : JpaRepository<Shop, Long> {
+
+    @EntityGraph(attributePaths = ["products"])
+    fun findOneWithProductsById(shopId: Long): Shop
+
+    @EntityGraph(attributePaths = ["reservableTimes"])
+    fun findOneWithReservableTimesById(shopId: Long): Shop
+}

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/kotlin/com/mealkitary/shop/adapter/output/persistence/SpringDataJpaShopPersistenceAdapter.kt
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/kotlin/com/mealkitary/shop/adapter/output/persistence/SpringDataJpaShopPersistenceAdapter.kt
@@ -1,0 +1,20 @@
+package com.mealkitary.shop.adapter.output.persistence
+
+import com.mealkitary.shop.application.port.output.LoadProductPort
+import com.mealkitary.shop.application.port.output.LoadReservableTimePort
+import com.mealkitary.shop.application.port.output.LoadShopPort
+import org.springframework.stereotype.Repository
+
+@Repository
+class SpringDataJpaShopPersistenceAdapter(
+    private val shopRepository: ShopRepository,
+) : LoadShopPort, LoadProductPort, LoadReservableTimePort {
+
+    override fun loadAllShop() = shopRepository.findAll()
+
+    override fun loadAllProductByShopId(shopId: Long) = shopRepository.findOneWithProductsById(shopId)
+        .products
+
+    override fun loadAllReservableTimeByShopId(shopId: Long) = shopRepository.findOneWithReservableTimesById(shopId)
+        .reservableTimes
+}

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/application.yml
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/application.yml
@@ -1,11 +1,20 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driverClassName: org.h2.Driver
-    username: sa
-    password: 1234
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    properties:
-      hibernate:
-        auto_quote_keyword: true
+    datasource:
+        url: jdbc:h2:mem:testdb
+        driverClassName: org.h2.Driver
+        username: sa
+        password: 1234
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        hibernate:
+            ddl-auto: create
+        properties:
+            hibernate:
+                auto_quote_keyword: true
+                format_sql: true
+        show-sql: true
+        defer-datasource-initialization: true
+    sql:
+        init:
+            mode: embedded
+            data-locations: classpath:data.sql

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/application.yml
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/application.yml
@@ -18,3 +18,4 @@ spring:
         init:
             mode: embedded
             data-locations: classpath:data.sql
+            encoding: UTF-8

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/data.sql
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/data.sql
@@ -1,0 +1,35 @@
+insert into shop
+values (1, 'VALID', '집밥뚝딱 철산점');
+insert into product
+values (1, '부대찌개', 15800, 1);
+insert into product
+values (2, '존슨탕', 19600, 1);
+insert into product
+values (3, '소불고기 샤브샤브', 13200, 1);
+insert into reservable_time
+values (1, '06:30');
+insert into reservable_time
+values (1, '09:30');
+insert into reservable_time
+values (1, '12:30');
+insert into reservable_time
+values (1, '18:30');
+
+
+insert into shop
+values (2, 'VALID', '집밥뚝딱 안양점');
+insert into product
+values (4, '비비고 만두', 3200, 2);
+insert into product
+values (5, '토마토 훠궈', 22000, 2);
+insert into product
+values (6, '닭가슴살 샐러드', 6600, 2);
+
+insert into shop
+values (3, 'VALID', '집밥뚝딱 숭실대입구점');
+insert into product
+values (7, '왕만두', 4900, 3);
+insert into product
+values (8, '토마토 파스타', 8800, 3);
+insert into product
+values (9, '알리오올리오 파스타', 9900, 3);

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/data.sql
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/data.sql
@@ -24,6 +24,10 @@ insert into product
 values (5, '토마토 훠궈', 22000, 2);
 insert into product
 values (6, '닭가슴살 샐러드', 6600, 2);
+insert into reservable_time
+values (2, '12:30');
+insert into reservable_time
+values (2, '19:30');
 
 insert into shop
 values (3, 'VALID', '집밥뚝딱 숭실대입구점');
@@ -33,3 +37,11 @@ insert into product
 values (8, '토마토 파스타', 8800, 3);
 insert into product
 values (9, '알리오올리오 파스타', 9900, 3);
+insert into reservable_time
+values (3, '16:30');
+insert into reservable_time
+values (3, '18:30');
+insert into reservable_time
+values (3, '20:00');
+insert into reservable_time
+values (3, '23:30');

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/test/kotlin/com/mealkitary/MealkitarySpringDataJpaPersistenceApplication.kt
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/test/kotlin/com/mealkitary/MealkitarySpringDataJpaPersistenceApplication.kt
@@ -1,0 +1,6 @@
+package com.mealkitary
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class MealkitarySpringDataJpaPersistenceApplication

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/test/kotlin/com/mealkitary/shop/adapter/output/persistence/SpringDataJpaShopPersistenceAdapterTest.kt
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/test/kotlin/com/mealkitary/shop/adapter/output/persistence/SpringDataJpaShopPersistenceAdapterTest.kt
@@ -1,0 +1,40 @@
+package com.mealkitary.shop.adapter.output.persistence
+
+import com.mealkitary.common.model.Money
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import java.time.LocalTime
+
+@DataJpaTest
+@Import(SpringDataJpaShopPersistenceAdapter::class)
+class SpringDataJpaShopPersistenceAdapterTest(
+    private val adapterUnderTest: SpringDataJpaShopPersistenceAdapter
+) : AnnotationSpec() {
+
+    override fun extensions() = listOf(SpringExtension)
+
+    @Test
+    fun `db integration test - 모든 가게를 조회한다`() {
+        val shops = adapterUnderTest.loadAllShop()
+        shops.size shouldBe 3
+        shops.get(0).title shouldBe "집밥뚝딱 철산점"
+    }
+
+    @Test
+    fun `db integration test - 가게 ID에 해당하는 가게의 상품 목록을 조회한다`() {
+        val products = adapterUnderTest.loadAllProductByShopId(1L)
+        products.size shouldBe 3
+        products.get(0).name shouldBe "부대찌개"
+        products.get(0).price shouldBe Money.of(15800)
+    }
+
+    @Test
+    fun `db integration test - 가게 ID에 해당하는 가게의 모든 예약 가능 시간을 조회한다`() {
+        val reservableTimes = adapterUnderTest.loadAllReservableTimeByShopId(1L)
+        reservableTimes.size shouldBe 4
+        reservableTimes.get(0) shouldBe LocalTime.of(6, 30)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,6 @@ include(
     "mealkitary-application",
     "mealkitary-domain",
     "mealkitary-infrastructure:adapter-persistence-spring-data-jpa",
-    "mealkitary-infrastructure:adapter-persistence-in-memory"
 )
 
 pluginManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,8 @@ include(
     "mealkitary-api",
     "mealkitary-application",
     "mealkitary-domain",
-    "mealkitary-infrastructure:adapter-persistence-spring-data-jpa"
+    "mealkitary-infrastructure:adapter-persistence-spring-data-jpa",
+    "mealkitary-infrastructure:adapter-persistence-in-memory"
 )
 
 pluginManagement {


### PR DESCRIPTION
**구현 요약**

- 가게 조회 기능 구현 : GET /shops/
- 상품 조회 기능 구현 : GET /shops/{shopId}/products
- 예약 가능 시간 조회 기능 구현 : GET /shops/{shopId}/reservable-time
- 상품, 가게, 금액, 예약 가능 시간 Entity 매핑

**주요 변경**
- kotlin getter, setter 검증 테스트 코드가 없어서 jacoco 라인 커버리지 제한 0.80 ->0.70으로 변경
- 가게 유효성 검사 반환 예외를 `IllegalArgumentException`에서 `IllegalStateException` 으로 변경
- kotest 버전을 `5.4.2`에서 `4.4.3`으로 변경
- 신규 의존성 추가(springmockk, kotest-spring-extension)

**연관 이슈**
#15 