### PR TITLE
[배포] 메인 브랜치 반영(PR#49)

### DIFF
--- a/.github/workflows/mealkitary-code-review-automation.yml
+++ b/.github/workflows/mealkitary-code-review-automation.yml
@@ -1,4 +1,4 @@
-name: GPT code review workflow
+name: Mealkitary Code Review Automation
 
 permissions:
     contents: read
@@ -19,6 +19,6 @@ jobs:
                     OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
                     LANGUAGE: Korean
                     OPENAI_API_ENDPOINT: https://api.openai.com/v1
-                    MODEL:
+                    MODEL: gpt-3.5-turbo
                     top_p: 1
                     temperature: 1

--- a/.github/workflows/mealkitary-main-cd.yml
+++ b/.github/workflows/mealkitary-main-cd.yml
@@ -9,6 +9,20 @@ jobs:
     cd:
         runs-on: ubuntu-latest
         steps:
+            -   id: check_pr_labels
+                name: PR 라벨 확인
+                shell: bash
+                run: |
+                    pull_request_labels=$(curl \
+                      --fail \
+                      -H "Accept: application/vnd.github.groot-preview+json" \
+                      -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                      "${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+                    | jq -r ".[0].labels[].name")
+
+                    if echo "$pull_request_labels" | grep -q '^no-deployment$' ; then
+                      echo "::set-output name=DEPLOYMENT::false"
+                    fi
             -   uses: actions/checkout@v3
             -   name: JDK 11 구성
                 uses: actions/setup-java@v3
@@ -31,13 +45,16 @@ jobs:
                         ${{ runner.os }}-gradle-
 
             -   name: Gradle 빌드
+                if: ${{ steps.check_pr_labels.outputs.DEPLOYMENT != 'false' }}
                 run: ./gradlew clean build
 
             -   name: Docker 로그인
+                if: ${{ steps.check_pr_labels.outputs.DEPLOYMENT != 'false' }}
                 uses: docker/login-action@v2
                 with:
                     username: ${{ secrets.DOCKERHUB_USERNAME }}
                     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
             -   name: 도커 이미지 빌드, 레지스트리 전송
+                if: ${{ steps.check_pr_labels.outputs.DEPLOYMENT != 'false' }}
                 run: ./gradlew jib

--- a/.github/workflows/mealkitary-main-cd.yml
+++ b/.github/workflows/mealkitary-main-cd.yml
@@ -1,4 +1,4 @@
-name: mealkitary main ci
+name: Mealkitary main CD
 
 on:
     push:
@@ -6,7 +6,7 @@ on:
             - 'main'
 
 jobs:
-    ci:
+    cd:
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3

--- a/.github/workflows/mealkitary-main-develop-ci.yml
+++ b/.github/workflows/mealkitary-main-develop-ci.yml
@@ -1,8 +1,9 @@
-name: Code Analyze - Pull Request
+name: Mealkitary main, develop CI
 
 permissions:
-    checks: write
+    contents: write
     pull-requests: write
+    checks: write
 
 on:
     pull_request:
@@ -11,7 +12,8 @@ on:
             - 'main'
 
 jobs:
-    code-analyze:
+    gradle-task-codecov:
+        if: ${{ contains(github.event.*.labels.*.name, format('run{0} ci', ':')) }}
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3
@@ -47,6 +49,7 @@ jobs:
                         ./mealkitary-domain/build/test-results/**/*.xml
                         ./mealkitary-application/build/test-results/**/*.xml
                         ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/test-results/**/*.xml
+                        ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/test-results/**/*.xml
 
             -   name: Jacoco Coverage 리포트 전송
                 uses: codecov/codecov-action@v3
@@ -56,6 +59,20 @@ jobs:
                         ./mealkitary-api/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-domain/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-application/build/reports/jacoco/test/jacocoTestReport.xml,
-                        ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml
+                        ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml,
+                        ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/reports/jacoco/test/jacocoTestReport.xml
                     name: mealkitary-codecov
                     verbose: true
+
+    qodana:
+        if: ${{ contains(github.event.*.labels.*.name, format('run{0} ci', ':')) }}
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v3
+                with:
+                    ref: ${{ github.event.pull_request.head.sha }}
+                    fetch-depth: 0
+            -   name: Qodana 정적 코드 분석 수행
+                uses: JetBrains/qodana-action@v2023.2
+                env:
+                    QODANA_TOKEN: ${{ secrets.QODANA_TOKEN }}

--- a/.github/workflows/mealkitary-test-coverage-automation.yml
+++ b/.github/workflows/mealkitary-test-coverage-automation.yml
@@ -37,6 +37,7 @@ jobs:
                         ./mealkitary-domain/build/test-results/**/*.xml
                         ./mealkitary-application/build/test-results/**/*.xml
                         ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/test-results/**/*.xml
+                        ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/test-results/**/*.xml
 
             -   name: Jacoco Coverage 리포트 전송
                 uses: codecov/codecov-action@v3
@@ -46,6 +47,7 @@ jobs:
                         ./mealkitary-api/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-domain/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-application/build/reports/jacoco/test/jacocoTestReport.xml,
-                        ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml
+                        ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml,
+                        ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/reports/jacoco/test/jacocoTestReport.xml
                     name: mealkitary-codecov
                     verbose: true

--- a/.github/workflows/mealkitary-test-coverage-automation.yml
+++ b/.github/workflows/mealkitary-test-coverage-automation.yml
@@ -1,4 +1,4 @@
-name: Jacoco Code Coverage & Test Result workflow
+name: Mealkitary Test Coverage Automation
 
 permissions:
     checks: write

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
     <a href="https://codecov.io/gh/le2sky/mealkitary-server" >
         <img src="https://codecov.io/gh/le2sky/mealkitary-server/branch/main/graph/badge.svg?token=MRR5C1OFUL"/>
     </a>
-    <a href="https://github.com/le2sky/mealkitary-server/.git/workflows/mealkitary-main-ci.yml">
-        <img src="https://github.com/le2sky/mealkitary-server/actions/workflows/mealkitary-main-ci.yml/badge.svg" alt="Build Status">
+    <a href="https://github.com/le2sky/mealkitary-server/.git/workflows/mealkitary-main-cd.yml">
+        <img src="https://github.com/le2sky/mealkitary-server/actions/workflows/mealkitary-main-cd.yml/badge.svg" alt="Build Status">
     </a>
 </p>
 


### PR DESCRIPTION
**구현 요약**

- 플로우에 대한 네이밍 개선과, 지속적 제공과 지속적 통합 개념을 분리하는 작업을 했습니다.
- CI 과정에서 코드 정적 분석 툴인 qodana를 추가했습니다.
- 지속적 제공을 하고 싶지 않을 경우, 사용할 수 있는 트리거를 구현했습니다.
- 애플리케이션 변경 사항 없으므로 버전은 0.1.1 유지합니다.

**연관 이슈**
close #48 