### PR TITLE
[설정] Location 헤더 노출 설정(issue#56)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ ktlintVersion=11.0.0
 springBootVersion=2.7.11
 springDependencyManagementVersion=1.0.15.RELEASE
 # project
-applicationVersion=0.2.0
+applicationVersion=0.3.0
 projectGroup=com.mealkitary
 # test
 kotestVersion=4.4.3

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/common/config/WebConfig.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/common/config/WebConfig.kt
@@ -1,6 +1,7 @@
 package com.mealkitary.common.config
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
 import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
@@ -10,5 +11,6 @@ class WebConfig : WebMvcConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
         registry.addMapping("/**")
             .allowedOrigins("*")
+            .exposedHeaders(HttpHeaders.LOCATION)
     }
 }


### PR DESCRIPTION
**구현 요약**

- Cors에 의해 Location 헤더가 노출되지 않는 문제를 해결하기 위해서 Location 헤더를 노출 설정했습니다.

**연관 이슈**
#56 