### PR TITLE
[개선] Location 리소스 경로 개선(issue#59)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ ktlintVersion=11.0.0
 springBootVersion=2.7.11
 springDependencyManagementVersion=1.0.15.RELEASE
 # project
-applicationVersion=0.3.0
+applicationVersion=0.3.1
 projectGroup=com.mealkitary
 # test
 kotestVersion=4.4.3

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/common/utils/HttpResponseUtils.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/common/utils/HttpResponseUtils.kt
@@ -11,20 +11,22 @@ class HttpResponseUtils {
 
         fun createResourceUri(resourceId: UUID): URI {
             val uriComponents = ServletUriComponentsBuilder.fromCurrentRequest().build()
-            val scheme = uriComponents.scheme
-            val host = uriComponents.host
-            val path = uriComponents.path
+            val scheme = removeSlash(uriComponents.scheme)
+            val host = removeSlash(uriComponents.host)
+            val path = removeSlash(uriComponents.path)
 
-            return URI.create("$scheme://$host$path/$resourceId")
+            return URI.create("$scheme://$host/$path/$resourceId")
         }
 
         fun createResourceUri(path: String, resourceId: UUID): URI {
             val uriComponents = ServletUriComponentsBuilder.fromCurrentRequest().build()
-            val scheme = uriComponents.scheme
-            val host = uriComponents.host
+            val scheme = removeSlash(uriComponents.scheme)
+            val host = removeSlash(uriComponents.host)
 
             return URI.create("$scheme://$host/$path/$resourceId")
         }
+
+        private fun removeSlash(str: String?) = str?.replace("/", "")
 
         fun <T> mapToResponseEntity(emptiableList: List<T>): ResponseEntity<List<T>> {
             if (emptiableList.isEmpty()) {

--- a/mealkitary-api/src/test/kotlin/com/mealkitary/reservation/adapter/input/web/GetReservationControllerTest.kt
+++ b/mealkitary-api/src/test/kotlin/com/mealkitary/reservation/adapter/input/web/GetReservationControllerTest.kt
@@ -10,7 +10,10 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class GetReservationControllerTest : WebIntegrationTestSupport() {
@@ -18,7 +21,9 @@ class GetReservationControllerTest : WebIntegrationTestSupport() {
     @Test
     fun `api integration test - getOneReservation`() {
         val reservationId = UUID.randomUUID()
-        val reserveAt = LocalDateTime.now()
+        val reserveAt = LocalDateTime.of(
+            LocalDate.of(2023, 6, 23), LocalTime.of(6, 30)
+        )
         every { getReservationQuery.loadOneReservationById(reservationId) } answers {
             ReservationResponse(
                 reservationId,
@@ -48,7 +53,7 @@ class GetReservationControllerTest : WebIntegrationTestSupport() {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.reservationId").value(reservationId.toString()))
             .andExpect(jsonPath("$.shopName").value("집밥뚝딱 안양점"))
-            .andExpect(jsonPath("$.reserveAt").value(reserveAt.toString()))
+            .andExpect(jsonPath("$.reserveAt").value(reserveAt.format(DateTimeFormatter.ISO_DATE_TIME)))
             .andExpect(jsonPath("$.status").value("PAID"))
             .andExpect(jsonPath("$.reservedProduct[0].productId").value(1L))
             .andExpect(jsonPath("$.reservedProduct[0].name").value("부대찌개"))


### PR DESCRIPTION
**구현 요약**
- 실제 반환되는 리소스 경로에서 localhost/reservation//id 형식으로 슬래시가 두개 있었습니다.
- 슬래시를 하나만 둬 유효한 리소스 경로를 반환하도록 개선했습니다.
- getOneReservation 컨트롤러 테스트가 포매팅 문제로 깨지는 문제를 개선했습니다.

**연관 이슈**
#59 