### PR TITLE
[개선] 가게 생성 시 주소 정보 추가 (issue#79)

### DIFF
--- a/.github/workflows/mealkitary-main-develop-ci.yml
+++ b/.github/workflows/mealkitary-main-develop-ci.yml
@@ -55,6 +55,7 @@ jobs:
                         ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/test-results/**/*.xml
                         ./mealkitary-infrastructure/adapter-firebase-notification/build/test-results/**/*.xml
                         ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/test-results/**/*.xml
+                        ./mealkitary-infrastructure/adapter-address-resolver/build/test-results/**/*.xml
 
             -   name: Jacoco Coverage 리포트 전송
                 uses: codecov/codecov-action@v3
@@ -67,7 +68,8 @@ jobs:
                         ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-infrastructure/adapter-firebase-notification/build/reports/jacoco/test/jacocoTestReport.xml,
-                        ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/reports/jacoco/test/jacocoTestReport.xml
+                        ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/reports/jacoco/test/jacocoTestReport.xml,
+                        ./mealkitary-infrastructure/adapter-address-resolver/build/reports/jacoco/test/jacocoTestReport.xml,
                     name: mealkitary-codecov
                     verbose: true
 

--- a/.github/workflows/mealkitary-main-develop-ci.yml
+++ b/.github/workflows/mealkitary-main-develop-ci.yml
@@ -69,7 +69,7 @@ jobs:
                         ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-infrastructure/adapter-firebase-notification/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/reports/jacoco/test/jacocoTestReport.xml,
-                        ./mealkitary-infrastructure/adapter-address-resolver/build/reports/jacoco/test/jacocoTestReport.xml,
+                        ./mealkitary-infrastructure/adapter-address-resolver/build/reports/jacoco/test/jacocoTestReport.xml
                     name: mealkitary-codecov
                     verbose: true
 

--- a/.github/workflows/mealkitary-test-coverage-automation.yml
+++ b/.github/workflows/mealkitary-test-coverage-automation.yml
@@ -43,6 +43,7 @@ jobs:
                         ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/test-results/**/*.xml
                         ./mealkitary-infrastructure/adapter-firebase-notification/build/test-results/**/*.xml
                         ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/test-results/**/*.xml
+                        ./mealkitary-infrastructure/adapter-address-resolver/build/test-results/**/*.xml
 
             -   name: Jacoco Coverage 리포트 전송
                 uses: codecov/codecov-action@v3
@@ -55,6 +56,8 @@ jobs:
                         ./mealkitary-infrastructure/adapter-persistence-spring-data-jpa/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-infrastructure/adapter-paymentgateway-tosspayments/build/reports/jacoco/test/jacocoTestReport.xml,
                         ./mealkitary-infrastructure/adapter-firebase-notification/build/reports/jacoco/test/jacocoTestReport.xml,
-                        ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/reports/jacoco/test/jacocoTestReport.xml
+                        ./mealkitary-infrastructure/business-registration-number-validator/adapter-simple-brn-validator/build/reports/jacoco/test/jacocoTestReport.xml,
+                        ./mealkitary-infrastructure/adapter-address-resolver/build/reports/jacoco/test/jacocoTestReport.xml
+
                     name: mealkitary-codecov
                     verbose: true

--- a/mealkitary-api/build.gradle.kts
+++ b/mealkitary-api/build.gradle.kts
@@ -6,6 +6,7 @@ val snippetsDir by extra { file("build/generated-snippets") }
 val asciidoctorExt: Configuration by configurations.creating
 
 bootJar.enabled = true
+bootJar.duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 jar.enabled = false
 
 plugins {

--- a/mealkitary-api/build.gradle.kts
+++ b/mealkitary-api/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":mealkitary-infrastructure:adapter-persistence-spring-data-jpa"))
     implementation(project(":mealkitary-infrastructure:adapter-paymentgateway-tosspayments"))
     implementation(project(":mealkitary-infrastructure:adapter-firebase-notification"))
+    implementation(project(":mealkitary-infrastructure:adapter-address-resolver"))
     implementation(
         project(
             ":mealkitary-infrastructure:business-registration-number-validator:adapter-open-api-brn-validator",

--- a/mealkitary-api/src/main/kotlin/com/mealkitary/shop/web/request/RegisterShopWebRequest.kt
+++ b/mealkitary-api/src/main/kotlin/com/mealkitary/shop/web/request/RegisterShopWebRequest.kt
@@ -8,8 +8,11 @@ data class RegisterShopWebRequest(
     val title: String? = null,
 
     @field:NotBlank(message = "사업자 번호는 필수입니다.")
-    val brn: String? = null
+    val brn: String? = null,
+
+    @field:NotBlank(message = "주소는 필수입니다.")
+    val address: String? = null
 ) {
 
-    fun mapToServiceRequest() = RegisterShopRequest(title!!, brn!!)
+    fun mapToServiceRequest() = RegisterShopRequest(title!!, brn!!, address!!)
 }

--- a/mealkitary-api/src/test/kotlin/com/docs/shop/RegisterShopControllerDocsTest.kt
+++ b/mealkitary-api/src/test/kotlin/com/docs/shop/RegisterShopControllerDocsTest.kt
@@ -28,7 +28,7 @@ class RegisterShopControllerDocsTest : RestDocsSupport() {
     fun `api docs test - registerShop`() {
         every { registerShopUseCase.register(any()) } answers { 1L }
 
-        val registerShopWebRequest = RegisterShopWebRequest("집밥뚝딱 안양점", "123-23-12345")
+        val registerShopWebRequest = RegisterShopWebRequest("집밥뚝딱 안양점", "123-23-12345", "경기도 안양시 동안구 벌말로")
 
         mvc.perform(
             RestDocumentationRequestBuilders.post("/shops")
@@ -45,6 +45,7 @@ class RegisterShopControllerDocsTest : RestDocsSupport() {
                     requestFields(
                         fieldWithPath("title").type(JsonFieldType.STRING).description("등록 대상 가게 이름"),
                         fieldWithPath("brn").type(JsonFieldType.STRING).description("사업자 번호"),
+                        fieldWithPath("address").type(JsonFieldType.STRING).description("가게 도로명 주소"),
                     ),
                     responseHeaders(headerWithName("Location").description("생성된 가게 리소스 URI")),
                 )

--- a/mealkitary-api/src/test/kotlin/com/mealkitary/shop/web/RegisterShopControllerTest.kt
+++ b/mealkitary-api/src/test/kotlin/com/mealkitary/shop/web/RegisterShopControllerTest.kt
@@ -15,7 +15,7 @@ class RegisterShopControllerTest : WebIntegrationTestSupport() {
     fun `api integration test - registerShop`() {
         every { registerShopUseCase.register(any()) } answers { 1L }
 
-        val registerShopWebRequest = RegisterShopWebRequest("집밥뚝딱 안양점", "123-23-12345")
+        val registerShopWebRequest = RegisterShopWebRequest("집밥뚝딱 안양점", "123-23-12345", "경기도 안양시 동안구 벌말로 40")
 
         mvc.perform(
             MockMvcRequestBuilders.post("/shops")
@@ -28,7 +28,7 @@ class RegisterShopControllerTest : WebIntegrationTestSupport() {
 
     @Test
     fun `api integration test - 가게 이름이 누락된 경우 400 에러를 발생한다`() {
-        val registerShopWebRequest = RegisterShopWebRequest(brn = "123-23-12345")
+        val registerShopWebRequest = RegisterShopWebRequest(brn = "123-23-12345", address = "경기도 안양시 동안구 벌말로 40")
 
         mvc.perform(
             MockMvcRequestBuilders.post("/shops")
@@ -44,7 +44,7 @@ class RegisterShopControllerTest : WebIntegrationTestSupport() {
 
     @Test
     fun `api integration test - 사업자 번호가 누락된 경우 400 에러를 발생한다`() {
-        val registerShopWebRequest = RegisterShopWebRequest(title = "집밥뚝딱 안양점")
+        val registerShopWebRequest = RegisterShopWebRequest(title = "집밥뚝딱 안양점", address = "경기도 안양시 동안구 벌말로 40")
 
         mvc.perform(
             MockMvcRequestBuilders.post("/shops")
@@ -56,6 +56,22 @@ class RegisterShopControllerTest : WebIntegrationTestSupport() {
             .andExpect(jsonPath("$.message").value("잘못된 입력값입니다."))
             .andExpect(jsonPath("$..errors[0].field").value("brn"))
             .andExpect(jsonPath("$..errors[0].reason").value("사업자 번호는 필수입니다."))
+    }
+
+    @Test
+    fun `api integration test - 주소가 누락된 경우 400 에러를 발생한다`() {
+        val registerShopWebRequest = RegisterShopWebRequest(title = "집밥뚝딱 안양점", brn = "123-23-12345")
+
+        mvc.perform(
+            MockMvcRequestBuilders.post("/shops")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(registerShopWebRequest))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.status").value("400"))
+            .andExpect(jsonPath("$.message").value("잘못된 입력값입니다."))
+            .andExpect(jsonPath("$..errors[0].field").value("address"))
+            .andExpect(jsonPath("$..errors[0].reason").value("주소는 필수입니다."))
     }
 
     @Test

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/RegisterShopRequest.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/port/input/RegisterShopRequest.kt
@@ -2,5 +2,6 @@ package com.mealkitary.shop.application.port.input
 
 data class RegisterShopRequest(
     val title: String,
-    val brn: String
+    val brn: String,
+    val address: String
 )

--- a/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/RegisterShopService.kt
+++ b/mealkitary-application/src/main/kotlin/com/mealkitary/shop/application/service/RegisterShopService.kt
@@ -3,23 +3,23 @@ package com.mealkitary.shop.application.service
 import com.mealkitary.shop.application.port.input.RegisterShopRequest
 import com.mealkitary.shop.application.port.input.RegisterShopUseCase
 import com.mealkitary.shop.application.port.output.SaveShopPort
-import com.mealkitary.shop.domain.shop.factory.ShopBusinessNumberValidator
 import com.mealkitary.shop.domain.shop.factory.ShopFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 class RegisterShopService(
     private val saveShopPort: SaveShopPort,
-    shopBusinessNumberValidator: ShopBusinessNumberValidator
+    private val shopFactory: ShopFactory
 ) : RegisterShopUseCase {
 
-    private val shopFactory = ShopFactory(shopBusinessNumberValidator)
-
-    @Transactional
     override fun register(registerShopRequest: RegisterShopRequest): Long {
-        val shop = shopFactory.createOne(registerShopRequest.title, registerShopRequest.brn)
+        val shop = shopFactory.createOne(
+            registerShopRequest.title,
+            registerShopRequest.brn,
+            registerShopRequest.address
+        )
 
         return saveShopPort.saveOne(shop)
     }

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
@@ -37,7 +37,7 @@ class GetShopServiceTest : AnnotationSpec() {
                             "region1DepthName",
                             "region2DepthName",
                             "region3DepthName",
-                            "region4DepthName"
+                            "roadName"
                         )
                     ),
                     mutableListOf(),

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
@@ -6,6 +6,9 @@ import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -24,6 +27,19 @@ class GetShopServiceTest : AnnotationSpec() {
                     ShopTitle.from("집밥뚝딱"),
                     ShopStatus.VALID,
                     ShopBusinessNumber.from("123-45-67890"),
+                    ShopAddress.of(
+                        "1234567890",
+                        Coordinates.of(
+                            126.99599512792346,
+                            35.976749396987046
+                        ),
+                        Address.of(
+                            "region1DepthName",
+                            "region2DepthName",
+                            "region3DepthName",
+                            "region4DepthName"
+                        )
+                    ),
                     mutableListOf(),
                     mutableListOf()
                 )

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/GetShopServiceTest.kt
@@ -1,13 +1,13 @@
 package com.mealkitary.shop.application.service
 
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.application.port.input.ShopResponse
 import com.mealkitary.shop.application.port.output.LoadShopPort
 import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/RegisterShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/RegisterShopServiceTest.kt
@@ -1,5 +1,7 @@
 package com.mealkitary.shop.application.service
 
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.application.port.input.RegisterShopRequest
 import com.mealkitary.shop.application.port.output.SaveShopPort
 import com.mealkitary.shop.domain.product.Product
@@ -7,8 +9,6 @@ import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import com.mealkitary.shop.domain.shop.factory.AddressResolver
 import com.mealkitary.shop.domain.shop.factory.ShopBusinessNumberValidator

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/RegisterShopServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/RegisterShopServiceTest.kt
@@ -2,8 +2,17 @@ package com.mealkitary.shop.application.service
 
 import com.mealkitary.shop.application.port.input.RegisterShopRequest
 import com.mealkitary.shop.application.port.output.SaveShopPort
+import com.mealkitary.shop.domain.product.Product
 import com.mealkitary.shop.domain.shop.Shop
+import com.mealkitary.shop.domain.shop.ShopBusinessNumber
+import com.mealkitary.shop.domain.shop.ShopStatus
+import com.mealkitary.shop.domain.shop.ShopTitle
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
+import com.mealkitary.shop.domain.shop.factory.AddressResolver
 import com.mealkitary.shop.domain.shop.factory.ShopBusinessNumberValidator
+import com.mealkitary.shop.domain.shop.factory.ShopFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -12,19 +21,36 @@ import io.kotest.matchers.throwable.shouldHaveMessage
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import java.time.LocalTime
 
 class RegisterShopServiceTest : AnnotationSpec() {
 
     private val saveShopPort = mockk<SaveShopPort>()
+    private val shopFactory = mockk<ShopFactory>()
     private val shopBusinessNumberValidator = mockk<ShopBusinessNumberValidator>()
-    private val registerShopService = RegisterShopService(saveShopPort, shopBusinessNumberValidator)
+    private val addressResolver = mockk<AddressResolver>()
+    private val registerShopService = RegisterShopService(saveShopPort, shopFactory)
 
     @Test
     fun `service unit test - 신규 가게를 등록한다`() {
         val shopSlot = slot<Shop>()
-        val request = RegisterShopRequest("집밥뚝딱 안양점", "123-23-12345")
+        val request = RegisterShopRequest("집밥뚝딱 안양점", "123-23-12345", "경기도 안양시 동안구 벌말로 40")
+        val expectedShopAddress =
+            ShopAddress.of("1234567890", Coordinates.of(0.0, 0.0), Address.of("경기도", "안양시 동안구", "벌말로", "40"))
+
+        val mockedShop = Shop(
+            ShopTitle.from(request.title),
+            ShopStatus.VALID,
+            ShopBusinessNumber.from(request.brn),
+            expectedShopAddress,
+            emptyList<LocalTime>().toMutableList(),
+            emptyList<Product>().toMutableList()
+        )
+
+        every {
+            shopFactory.createOne(request.title, request.brn, request.address)
+        } returns mockedShop
         every { saveShopPort.saveOne(capture(shopSlot)) } answers { 1L }
-        every { shopBusinessNumberValidator.validate(any()) } answers {}
 
         val result = registerShopService.register(request)
 
@@ -32,15 +58,23 @@ class RegisterShopServiceTest : AnnotationSpec() {
         result shouldBe 1L
         capturedShop.businessNumber.value shouldBe "123-23-12345"
         capturedShop.title.value shouldBe "집밥뚝딱 안양점"
+        capturedShop.address shouldBe expectedShopAddress
         capturedShop.products.shouldBeEmpty()
         capturedShop.reservableTimes.shouldBeEmpty()
     }
 
     @Test
     fun `service unit test - 가게 이름 형식에 맞지 않으면 예외를 발생한다`() {
-        val request = RegisterShopRequest("invalid!#@", "123-23-12345")
+        val request = RegisterShopRequest("invalid!#@", "123-23-12345", "경기도 안양시 동안구 벌말로 40")
+        val expectedShopAddress =
+            ShopAddress.of("1234567890", Coordinates.of(0.0, 0.0), Address.of("경기도", "안양시 동안구", "벌말로", "40"))
+
+        every {
+            shopFactory.createOne(any(), any(), any())
+        } throws IllegalArgumentException("올바른 가게 이름 형식이 아닙니다.(한글, 영문, 공백, 숫자만 포함 가능)")
         every { saveShopPort.saveOne(any()) } answers { 1L }
         every { shopBusinessNumberValidator.validate(any()) } answers {}
+        every { addressResolver.resolveAddress("경기도 안양시 동안구 벌말로 40") } returns expectedShopAddress
 
         shouldThrow<IllegalArgumentException> {
             registerShopService.register(request)
@@ -49,7 +83,11 @@ class RegisterShopServiceTest : AnnotationSpec() {
 
     @Test
     fun `service unit test - 사업자 번호 형식에 맞지 않으면 예외를 발생한다`() {
-        val request = RegisterShopRequest("집밥뚝딱 안양점", "invalid-brn")
+        val request = RegisterShopRequest("집밥뚝딱 안양점", "invalid-brn", "경기도 안양시 동안구 벌말로 40")
+
+        every {
+            shopFactory.createOne(any(), any(), any())
+        } throws IllegalArgumentException("올바른 사업자번호 형식이 아닙니다.")
         every { saveShopPort.saveOne(any()) } answers { 1L }
         every { shopBusinessNumberValidator.validate(any()) } answers {}
 

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/UpdateShopStatusServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/UpdateShopStatusServiceTest.kt
@@ -1,13 +1,13 @@
 package com.mealkitary.shop.application.service
 
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.application.port.output.CheckExistenceShopPort
 import com.mealkitary.shop.application.port.output.LoadShopPort
 import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/UpdateShopStatusServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/UpdateShopStatusServiceTest.kt
@@ -6,6 +6,9 @@ import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
@@ -25,6 +28,19 @@ class UpdateShopStatusServiceTest : AnnotationSpec() {
             ShopTitle.from("제목"),
             ShopStatus.VALID,
             ShopBusinessNumber.from("123-12-12345"),
+            ShopAddress.of(
+                "1234567890",
+                Coordinates.of(
+                    126.99599512792346,
+                    35.976749396987046
+                ),
+                Address.of(
+                    "region1DepthName",
+                    "region2DepthName",
+                    "region3DepthName",
+                    "region4DepthName"
+                )
+            ),
             mutableListOf(),
             mutableListOf()
         )
@@ -44,6 +60,19 @@ class UpdateShopStatusServiceTest : AnnotationSpec() {
             ShopTitle.from("제목"),
             ShopStatus.INVALID,
             ShopBusinessNumber.from("123-12-12345"),
+            ShopAddress.of(
+                "1234567890",
+                Coordinates.of(
+                    126.99599512792346,
+                    35.976749396987046
+                ),
+                Address.of(
+                    "region1DepthName",
+                    "region2DepthName",
+                    "region3DepthName",
+                    "region4DepthName"
+                )
+            ),
             mutableListOf(),
             mutableListOf()
         )
@@ -63,6 +92,19 @@ class UpdateShopStatusServiceTest : AnnotationSpec() {
             ShopTitle.from("제목"),
             ShopStatus.VALID,
             ShopBusinessNumber.from("123-12-12345"),
+            ShopAddress.of(
+                "1234567890",
+                Coordinates.of(
+                    126.99599512792346,
+                    35.976749396987046
+                ),
+                Address.of(
+                    "region1DepthName",
+                    "region2DepthName",
+                    "region3DepthName",
+                    "region4DepthName"
+                )
+            ),
             mutableListOf(),
             mutableListOf()
         )

--- a/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/UpdateShopStatusServiceTest.kt
+++ b/mealkitary-application/src/test/kotlin/com/mealkitary/shop/application/service/UpdateShopStatusServiceTest.kt
@@ -38,7 +38,7 @@ class UpdateShopStatusServiceTest : AnnotationSpec() {
                     "region1DepthName",
                     "region2DepthName",
                     "region3DepthName",
-                    "region4DepthName"
+                    "roadName"
                 )
             ),
             mutableListOf(),
@@ -70,7 +70,7 @@ class UpdateShopStatusServiceTest : AnnotationSpec() {
                     "region1DepthName",
                     "region2DepthName",
                     "region3DepthName",
-                    "region4DepthName"
+                    "roadName"
                 )
             ),
             mutableListOf(),
@@ -102,7 +102,7 @@ class UpdateShopStatusServiceTest : AnnotationSpec() {
                     "region1DepthName",
                     "region2DepthName",
                     "region3DepthName",
-                    "region4DepthName"
+                    "roadName"
                 )
             ),
             mutableListOf(),

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/common/model/Address.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/common/model/Address.kt
@@ -1,10 +1,10 @@
-package com.mealkitary.shop.domain.shop.address
+package com.mealkitary.common.model
 
 import javax.persistence.Column
 import javax.persistence.Embeddable
 
 @Embeddable
-class Address(
+class Address private constructor(
     @Column(name = "region_1depth_name", nullable = false)
     val region1DepthName: String,
     @Column(name = "region_2depth_name", nullable = false)

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/common/model/Coordinates.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/common/model/Coordinates.kt
@@ -1,4 +1,4 @@
-package com.mealkitary.shop.domain.shop.address
+package com.mealkitary.common.model
 
 import javax.persistence.Column
 import javax.persistence.Embeddable

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/Shop.kt
@@ -1,6 +1,7 @@
 package com.mealkitary.shop.domain.shop
 
 import com.mealkitary.shop.domain.product.Product
+import com.mealkitary.shop.domain.shop.address.ShopAddress
 import java.time.LocalDateTime
 import java.time.LocalTime
 import javax.persistence.CascadeType
@@ -23,6 +24,7 @@ class Shop(
     title: ShopTitle,
     status: ShopStatus,
     businessNumber: ShopBusinessNumber,
+    address: ShopAddress,
     reservableTimes: MutableList<LocalTime>,
     products: MutableList<Product>
 ) {
@@ -57,6 +59,8 @@ class Shop(
         protected set
 
     val businessNumber: ShopBusinessNumber = businessNumber
+
+    val address: ShopAddress = address
 
     fun checkReservableShop() {
         if (status.isInvalidStatus()) {

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Address.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Address.kt
@@ -11,8 +11,8 @@ class Address(
     val region2DepthName: String,
     @Column(name = "region_3depth_name")
     val region3DepthName: String,
-    @Column(name = "region_4depth_name")
-    val region4DepthName: String
+    @Column(name = "road_name")
+    val roadName: String
 ) {
 
     companion object {
@@ -20,14 +20,14 @@ class Address(
             region1DepthName: String,
             region2DepthName: String,
             region3DepthName: String,
-            region4DepthName: String
+            roadName: String
         ): Address {
 
             return Address(
                 region1DepthName,
                 region2DepthName,
                 region3DepthName,
-                region4DepthName
+                roadName
             )
         }
     }

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Address.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Address.kt
@@ -1,0 +1,34 @@
+package com.mealkitary.shop.domain.shop.address
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class Address(
+    @Column(name = "region_1depth_name", nullable = false)
+    val region1DepthName: String,
+    @Column(name = "region_2depth_name", nullable = false)
+    val region2DepthName: String,
+    @Column(name = "region_3depth_name")
+    val region3DepthName: String,
+    @Column(name = "region_4depth_name")
+    val region4DepthName: String
+) {
+
+    companion object {
+        fun of(
+            region1DepthName: String,
+            region2DepthName: String,
+            region3DepthName: String,
+            region4DepthName: String
+        ): Address {
+
+            return Address(
+                region1DepthName,
+                region2DepthName,
+                region3DepthName,
+                region4DepthName
+            )
+        }
+    }
+}

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Coordinates.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Coordinates.kt
@@ -1,0 +1,27 @@
+package com.mealkitary.shop.domain.shop.address
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+class Coordinates(
+    @Column(name = "longitude", nullable = false)
+    val longitude: Double,
+    @Column(name = "latitude", nullable = false)
+    val latitude: Double
+) {
+
+    companion object {
+        fun of(longitude: Double, latitude: Double): Coordinates {
+            checkIsCoordinate(longitude, latitude)
+
+            return Coordinates(longitude, latitude)
+        }
+
+        private fun checkIsCoordinate(longitude: Double, latitude: Double) {
+            if (longitude !in -180.0..180.0 || latitude !in -90.0..90.0) {
+                throw IllegalArgumentException("유효하지 않은 좌표 범위입니다.")
+            }
+        }
+    }
+}

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Coordinates.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/Coordinates.kt
@@ -13,12 +13,12 @@ class Coordinates(
 
     companion object {
         fun of(longitude: Double, latitude: Double): Coordinates {
-            checkIsCoordinate(longitude, latitude)
+            checkIsCoordinateRange(longitude, latitude)
 
             return Coordinates(longitude, latitude)
         }
 
-        private fun checkIsCoordinate(longitude: Double, latitude: Double) {
+        private fun checkIsCoordinateRange(longitude: Double, latitude: Double) {
             if (longitude !in -180.0..180.0 || latitude !in -90.0..90.0) {
                 throw IllegalArgumentException("유효하지 않은 좌표 범위입니다.")
             }

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/ShopAddress.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/ShopAddress.kt
@@ -1,5 +1,7 @@
 package com.mealkitary.shop.domain.shop.address
 
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import javax.persistence.Column
 import javax.persistence.Embeddable
 import javax.persistence.Embedded

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/ShopAddress.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/ShopAddress.kt
@@ -4,6 +4,8 @@ import javax.persistence.Column
 import javax.persistence.Embeddable
 import javax.persistence.Embedded
 
+private const val CITY_CODE_LENGTH = 10
+
 @Embeddable
 class ShopAddress private constructor(
     @Column(name = "city_code", nullable = false)
@@ -22,7 +24,7 @@ class ShopAddress private constructor(
         }
 
         private fun checkIsCityCodeLength(cityCode: String) {
-            if (cityCode.length != 10) {
+            if (cityCode.length != CITY_CODE_LENGTH) {
                 throw IllegalArgumentException("올바른 지역 코드가 아닙니다. (행정동 지역 코드는 10자리)")
             }
         }

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/ShopAddress.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/address/ShopAddress.kt
@@ -1,0 +1,30 @@
+package com.mealkitary.shop.domain.shop.address
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.Embedded
+
+@Embeddable
+class ShopAddress private constructor(
+    @Column(name = "city_code", nullable = false)
+    val cityCode: String,
+    @Embedded
+    val coordinates: Coordinates,
+    @Embedded
+    val address: Address
+) {
+
+    companion object {
+        fun of(cityCode: String, coordinates: Coordinates, address: Address): ShopAddress {
+            checkIsCityCodeLength(cityCode)
+
+            return ShopAddress(cityCode, coordinates, address)
+        }
+
+        private fun checkIsCityCodeLength(cityCode: String) {
+            if (cityCode.length != 10) {
+                throw IllegalArgumentException("올바른 지역 코드가 아닙니다. (행정동 지역 코드는 10자리)")
+            }
+        }
+    }
+}

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/AddressResolver.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/AddressResolver.kt
@@ -1,0 +1,8 @@
+package com.mealkitary.shop.domain.shop.factory
+
+import com.mealkitary.shop.domain.shop.address.ShopAddress
+
+interface AddressResolver {
+
+    fun resolveAddress(address: String): ShopAddress
+}

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactory.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactory.kt
@@ -6,10 +6,8 @@ import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
 import com.mealkitary.shop.domain.shop.address.ShopAddress
-import org.springframework.stereotype.Component
 import java.time.LocalTime
 
-@Component
 class ShopFactory(
     private val shopBusinessNumberValidator: ShopBusinessNumberValidator,
     private val addressResolver: AddressResolver

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactory.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactory.kt
@@ -5,14 +5,20 @@ import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
+import com.mealkitary.shop.domain.shop.address.ShopAddress
+import org.springframework.stereotype.Component
 import java.time.LocalTime
 
+@Component
 class ShopFactory(
-    private val shopBusinessNumberValidator: ShopBusinessNumberValidator
+    private val shopBusinessNumberValidator: ShopBusinessNumberValidator,
+    private val addressResolver: AddressResolver
 ) {
 
-    fun createOne(title: String, brn: String): Shop {
+    fun createOne(title: String, brn: String, address: String): Shop {
         val shopBusinessNumber = ShopBusinessNumber.from(brn)
+
+        val shopAddress: ShopAddress = addressResolver.resolveAddress(address)
 
         shopBusinessNumberValidator.validate(shopBusinessNumber)
 
@@ -20,6 +26,7 @@ class ShopFactory(
             ShopTitle.from(title),
             ShopStatus.VALID,
             shopBusinessNumber,
+            shopAddress,
             emptyList<LocalTime>().toMutableList(),
             emptyList<Product>().toMutableList(),
         )

--- a/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactory.kt
+++ b/mealkitary-domain/src/main/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactory.kt
@@ -6,8 +6,10 @@ import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
 import com.mealkitary.shop.domain.shop.address.ShopAddress
+import org.springframework.stereotype.Component
 import java.time.LocalTime
 
+@Component
 class ShopFactory(
     private val shopBusinessNumberValidator: ShopBusinessNumberValidator,
     private val addressResolver: AddressResolver

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/AddressTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/AddressTest.kt
@@ -1,6 +1,6 @@
 package com.mealkitary.shop.domain.shop
 
-import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.common.model.Address
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
 

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/AddressTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/AddressTest.kt
@@ -11,18 +11,18 @@ class AddressTest : AnnotationSpec() {
         val region1DepthName = "서울"
         val region2DepthName = "강남구"
         val region3DepthName = "논현동"
-        val region4DepthName = "논현로"
+        val roadName = "논현로"
 
         val address = Address.of(
             region1DepthName,
             region2DepthName,
             region3DepthName,
-            region4DepthName
+            roadName
         )
 
         address.region1DepthName shouldBe region1DepthName
         address.region2DepthName shouldBe region2DepthName
         address.region3DepthName shouldBe region3DepthName
-        address.region4DepthName shouldBe region4DepthName
+        address.roadName shouldBe roadName
     }
 }

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/AddressTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/AddressTest.kt
@@ -1,0 +1,28 @@
+package com.mealkitary.shop.domain.shop
+
+import com.mealkitary.shop.domain.shop.address.Address
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+
+class AddressTest : AnnotationSpec() {
+
+    @Test
+    fun `올바른 주소를 입력할 경우 객체를 생성할 수 있다`() {
+        val region1DepthName = "서울"
+        val region2DepthName = "강남구"
+        val region3DepthName = "논현동"
+        val region4DepthName = "논현로"
+
+        val address = Address.of(
+            region1DepthName,
+            region2DepthName,
+            region3DepthName,
+            region4DepthName
+        )
+
+        address.region1DepthName shouldBe region1DepthName
+        address.region2DepthName shouldBe region2DepthName
+        address.region3DepthName shouldBe region3DepthName
+        address.region4DepthName shouldBe region4DepthName
+    }
+}

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/CoordinatesTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/CoordinatesTest.kt
@@ -1,0 +1,31 @@
+package com.mealkitary.shop.domain.shop
+
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+
+class CoordinatesTest : AnnotationSpec() {
+
+    @Test
+    fun `범위를 벗어나는 좌표일 경우 예외를 발생한다`() {
+        val longitude = -188.023
+        val latitude = 999.7412
+
+        shouldThrow<IllegalArgumentException> {
+            Coordinates.of(longitude, latitude)
+        } shouldHaveMessage "유효하지 않은 좌표 범위입니다."
+    }
+
+    @Test
+    fun `올바른 좌표를 입력했을 경우 객체를 생성한다`() {
+        val longitude = -150.653
+        val latitude = 46.492
+
+        val coordinates = Coordinates.of(longitude, latitude)
+
+        coordinates.longitude shouldBe longitude
+        coordinates.latitude shouldBe latitude
+    }
+}

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/CoordinatesTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/CoordinatesTest.kt
@@ -1,6 +1,6 @@
 package com.mealkitary.shop.domain.shop
 
-import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.common.model.Coordinates
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopAddressTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopAddressTest.kt
@@ -21,7 +21,7 @@ class ShopAddressTest : AnnotationSpec() {
             "region1DepthName",
             "region2DepthName",
             "region3DepthName",
-            "region4DepthName"
+            "roadName"
         )
 
         val shopAddress = ShopAddress.of(
@@ -46,7 +46,7 @@ class ShopAddressTest : AnnotationSpec() {
             "region1DepthName",
             "region2DepthName",
             "region3DepthName",
-            "region4DepthName"
+            "roadName"
         )
 
         shouldThrow<IllegalArgumentException> {

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopAddressTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopAddressTest.kt
@@ -1,7 +1,7 @@
 package com.mealkitary.shop.domain.shop
 
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopAddressTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/ShopAddressTest.kt
@@ -1,0 +1,60 @@
+package com.mealkitary.shop.domain.shop
+
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+
+class ShopAddressTest : AnnotationSpec() {
+
+    @Test
+    fun `올바른 값들을 입력했을 경우 객체를 생성할 수 있다`() {
+        val cityCode = "1234567890"
+        val coordinates = Coordinates.of(
+            -150.653,
+            46.492
+        )
+        val address = Address.of(
+            "region1DepthName",
+            "region2DepthName",
+            "region3DepthName",
+            "region4DepthName"
+        )
+
+        val shopAddress = ShopAddress.of(
+            cityCode,
+            coordinates,
+            address
+        )
+
+        shopAddress.cityCode shouldBe cityCode
+        shopAddress.coordinates shouldBe coordinates
+        shopAddress.address shouldBe address
+    }
+
+    @Test
+    fun `지역 코드가 올바르지 않을 경우 예외를 발생한다`() {
+        val cityCode = "25231491723109"
+        val coordinates = Coordinates.of(
+            -150.653,
+            46.492
+        )
+        val address = Address.of(
+            "region1DepthName",
+            "region2DepthName",
+            "region3DepthName",
+            "region4DepthName"
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            ShopAddress.of(
+                cityCode,
+                coordinates,
+                address
+            )
+        } shouldHaveMessage "올바른 지역 코드가 아닙니다. (행정동 지역 코드는 10자리)"
+    }
+}

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactoryTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactoryTest.kt
@@ -1,7 +1,7 @@
 package com.mealkitary.shop.domain.shop.factory
 
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec

--- a/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactoryTest.kt
+++ b/mealkitary-domain/src/test/kotlin/com/mealkitary/shop/domain/shop/factory/ShopFactoryTest.kt
@@ -1,5 +1,8 @@
 package com.mealkitary.shop.domain.shop.factory
 
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.shouldBe
@@ -10,31 +13,66 @@ import io.mockk.mockk
 class ShopFactoryTest : AnnotationSpec() {
 
     private val shopBusinessNumberValidator = mockk<ShopBusinessNumberValidator>()
-    private val shopFactory = ShopFactory(shopBusinessNumberValidator)
+    private val addressResolver = mockk<AddressResolver>()
+    private val shopFactory = ShopFactory(shopBusinessNumberValidator, addressResolver)
 
     @Test
     fun `사업자번호가 유효하지 않으면 예외를 발생한다`() {
         shouldThrow<IllegalArgumentException> {
-            shopFactory.createOne("집밥뚝딱 안양점", "32-12-3221")
+            shopFactory.createOne("집밥뚝딱 안양점", "32-12-3221", "경기도 안양시 동안구 벌말로 40")
         } shouldHaveMessage "올바른 사업자번호 형식이 아닙니다."
     }
 
     @Test
-    fun `실제로 유효한 사업자번호와 가게이름이라면 가게를 생성한다`() {
-        every { shopBusinessNumberValidator.validate(any()) } answers { }
+    fun `실제로 유효한 사업자번호와 가게이름, 주소라면 가게를 생성한다`() {
+        val expectedShopAddress =
+            ShopAddress.of("1234567890", Coordinates.of(0.0, 0.0), Address.of("경기도", "안양시 동안구", "벌말로", "40"))
 
-        val shop = shopFactory.createOne("집밥뚝딱 안양점", "321-23-12345")
+        every { shopBusinessNumberValidator.validate(any()) } answers { }
+        every { addressResolver.resolveAddress("경기도 안양시 동안구 벌말로 40") } returns expectedShopAddress
+
+        val shop = shopFactory.createOne("집밥뚝딱 안양점", "321-23-12345", "경기도 안양시 동안구 벌말로 40")
 
         shop.title.value shouldBe "집밥뚝딱 안양점"
         shop.businessNumber.value shouldBe "321-23-12345"
+        shop.address shouldBe expectedShopAddress
     }
 
     @Test
     fun `가게 이름이 유효하지 않으면 예외를 발생한다`() {
+        val expectedShopAddress =
+            ShopAddress.of("1234567890", Coordinates.of(0.0, 0.0), Address.of("경기도", "안양시 동안구", "벌말로", "40"))
+
         every { shopBusinessNumberValidator.validate(any()) } answers { }
+        every { addressResolver.resolveAddress("경기도 안양시 동안구 벌말로 40") } returns expectedShopAddress
 
         shouldThrow<IllegalArgumentException> {
-            shopFactory.createOne("집밥뚝딱 ! 안양점", "321-23-12345")
+            shopFactory.createOne("집밥뚝딱 ! 안양점", "321-23-12345", "경기도 안양시 동안구 벌말로 40")
+        } shouldHaveMessage "올바른 가게 이름 형식이 아닙니다.(한글, 영문, 공백, 숫자만 포함 가능)"
+    }
+
+    @Test
+    fun `도로명 주소를 받아 주소 객체를 생선한다`() {
+        val address = "경기도 안양시 동안구 벌말로"
+        val shopAddress = ShopAddress.of(
+            "1234567890",
+            Coordinates.of(
+                127.0,
+                40.0
+            ),
+            Address.of(
+                "경기도",
+                "안양시",
+                "동안구",
+                "벌말로"
+            )
+        )
+
+        every { shopBusinessNumberValidator.validate(any()) } answers { }
+        every { addressResolver.resolveAddress(address) } answers { shopAddress }
+
+        shouldThrow<IllegalArgumentException> {
+            shopFactory.createOne("집밥뚝딱 ! 안양점", "321-23-12345", "경기도 안양시 동안구 벌말로 40")
         } shouldHaveMessage "올바른 가게 이름 형식이 아닙니다.(한글, 영문, 공백, 숫자만 포함 가능)"
     }
 }

--- a/mealkitary-domain/src/testFixtures/kotlin/data/ShopTestData.kt
+++ b/mealkitary-domain/src/testFixtures/kotlin/data/ShopTestData.kt
@@ -1,12 +1,12 @@
 package data
 
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.domain.product.Product
 import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import data.ProductTestData.Companion.defaultProduct
 import java.time.LocalTime

--- a/mealkitary-domain/src/testFixtures/kotlin/data/ShopTestData.kt
+++ b/mealkitary-domain/src/testFixtures/kotlin/data/ShopTestData.kt
@@ -5,6 +5,9 @@ import com.mealkitary.shop.domain.shop.Shop
 import com.mealkitary.shop.domain.shop.ShopBusinessNumber
 import com.mealkitary.shop.domain.shop.ShopStatus
 import com.mealkitary.shop.domain.shop.ShopTitle
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
 import data.ProductTestData.Companion.defaultProduct
 import java.time.LocalTime
 
@@ -22,7 +25,20 @@ class ShopTestData {
             defaultProduct().withId(1L).withName("부대찌개").build(),
             defaultProduct().withId(2L).withName("닭볶음탕").build()
         ),
-        private var shopBusinessNumber: ShopBusinessNumber = ShopBusinessNumber.from("123-45-67890")
+        private var shopBusinessNumber: ShopBusinessNumber = ShopBusinessNumber.from("123-45-67890"),
+        private var shopAddress: ShopAddress = ShopAddress.of(
+            "1234567890",
+            Coordinates.of(
+                126.99599512792346,
+                35.976749396987046
+            ),
+            Address.of(
+                "region1DepthName",
+                "region2DepthName",
+                "region3DepthName",
+                "roadName"
+            )
+        )
     ) {
 
         fun withTitle(title: String): ShopBuilder {
@@ -50,11 +66,17 @@ class ShopTestData {
             return this
         }
 
+        fun withAddress(shopAddress: ShopAddress): ShopBuilder {
+            this.shopAddress = shopAddress
+            return this
+        }
+
         fun build(): Shop {
             return Shop(
                 ShopTitle.from(this.title),
                 this.shopStatus,
                 this.shopBusinessNumber,
+                this.shopAddress,
                 this.reservableTimes.toMutableList(),
                 this.products.toMutableList()
             )

--- a/mealkitary-infrastructure/adapter-address-resolver/build.gradle.kts
+++ b/mealkitary-infrastructure/adapter-address-resolver/build.gradle.kts
@@ -1,0 +1,8 @@
+dependencies {
+    val querydslVersion: String by properties
+    implementation("com.querydsl:querydsl-jpa:$querydslVersion")
+    implementation("com.h2database:h2")
+    implementation(project(":mealkitary-domain"))
+    implementation(project(":mealkitary-application"))
+    testImplementation(testFixtures(project(":mealkitary-domain")))
+}

--- a/mealkitary-infrastructure/adapter-address-resolver/src/main/kotlin/com/mealkitary/address/SimpleAddressResolver.kt
+++ b/mealkitary-infrastructure/adapter-address-resolver/src/main/kotlin/com/mealkitary/address/SimpleAddressResolver.kt
@@ -21,7 +21,7 @@ class SimpleAddressResolver : AddressResolver {
         val region1DepthName = value[0]
         val region2DepthName = value[1]
         val region3DepthName = value.getOrNull(2) ?: ""
-        val region4DepthName = value.getOrNull(3) ?: ""
+        val roadName = value.getOrNull(3) ?: ""
 
         // TODO: 좌표 및 지역 코드를 카카오 API에서 받아올 예정
         return ShopAddress.of(
@@ -34,7 +34,7 @@ class SimpleAddressResolver : AddressResolver {
                 region1DepthName,
                 region2DepthName,
                 region3DepthName,
-                region4DepthName
+                roadName
             )
         )
     }

--- a/mealkitary-infrastructure/adapter-address-resolver/src/main/kotlin/com/mealkitary/address/SimpleAddressResolver.kt
+++ b/mealkitary-infrastructure/adapter-address-resolver/src/main/kotlin/com/mealkitary/address/SimpleAddressResolver.kt
@@ -1,0 +1,41 @@
+package com.mealkitary.address
+
+import com.mealkitary.shop.domain.shop.address.Address
+import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.shop.domain.shop.address.ShopAddress
+import com.mealkitary.shop.domain.shop.factory.AddressResolver
+import org.springframework.stereotype.Component
+
+private const val ADDRESS_MIN_LENGTH = 2
+
+@Component
+class SimpleAddressResolver : AddressResolver {
+
+    override fun resolveAddress(address: String): ShopAddress {
+        val value = address.split(" ")
+
+        if (value.size < ADDRESS_MIN_LENGTH) {
+            throw IllegalArgumentException("주소 형식이 올바르지 않습니다.")
+        }
+
+        val region1DepthName = value[0]
+        val region2DepthName = value[1]
+        val region3DepthName = value.getOrNull(2) ?: ""
+        val region4DepthName = value.getOrNull(3) ?: ""
+
+        // TODO: 좌표 및 지역 코드를 카카오 API에서 받아올 예정
+        return ShopAddress.of(
+            "1234567890",
+            Coordinates.of(
+                127.0,
+                40.0
+            ),
+            Address.of(
+                region1DepthName,
+                region2DepthName,
+                region3DepthName,
+                region4DepthName
+            )
+        )
+    }
+}

--- a/mealkitary-infrastructure/adapter-address-resolver/src/main/kotlin/com/mealkitary/address/SimpleAddressResolver.kt
+++ b/mealkitary-infrastructure/adapter-address-resolver/src/main/kotlin/com/mealkitary/address/SimpleAddressResolver.kt
@@ -1,7 +1,7 @@
 package com.mealkitary.address
 
-import com.mealkitary.shop.domain.shop.address.Address
-import com.mealkitary.shop.domain.shop.address.Coordinates
+import com.mealkitary.common.model.Address
+import com.mealkitary.common.model.Coordinates
 import com.mealkitary.shop.domain.shop.address.ShopAddress
 import com.mealkitary.shop.domain.shop.factory.AddressResolver
 import org.springframework.stereotype.Component

--- a/mealkitary-infrastructure/adapter-address-resolver/src/test/kotlin/SimpleAddressResolverTest.kt
+++ b/mealkitary-infrastructure/adapter-address-resolver/src/test/kotlin/SimpleAddressResolverTest.kt
@@ -1,0 +1,69 @@
+package com.mealkitary.address
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.springframework.stereotype.Component
+
+@Component
+class SimpleAddressResolverTest : AnnotationSpec() {
+
+    @Test
+    fun `adapter unit test - 문자열 주소값을 받아 주소 객체를 생성한다`() {
+        val address = "서울특별시 강남구 역삼동 논현로"
+        val resolver = SimpleAddressResolver()
+
+        val shopAddress = resolver.resolveAddress(address)
+
+        shopAddress.cityCode shouldBe "1234567890"
+        shopAddress.coordinates.longitude shouldBe 127.0
+        shopAddress.coordinates.latitude shouldBe 40.0
+        shopAddress.address.region1DepthName shouldBe "서울특별시"
+        shopAddress.address.region2DepthName shouldBe "강남구"
+        shopAddress.address.region3DepthName shouldBe "역삼동"
+        shopAddress.address.region4DepthName shouldBe "논현로"
+    }
+
+    @Test
+    fun `adapter unit test - 문자열 주소값이 3등분일 경우 3개의 정보를 가진 주소 객체를 생성한다`() {
+        val address = "경기도 남양주시 다산동"
+        val resolver = SimpleAddressResolver()
+
+        val shopAddress = resolver.resolveAddress(address)
+
+        shopAddress.cityCode shouldBe "1234567890"
+        shopAddress.coordinates.longitude shouldBe 127.0
+        shopAddress.coordinates.latitude shouldBe 40.0
+        shopAddress.address.region1DepthName shouldBe "경기도"
+        shopAddress.address.region2DepthName shouldBe "남양주시"
+        shopAddress.address.region3DepthName shouldBe "다산동"
+        shopAddress.address.region4DepthName shouldBe ""
+    }
+
+    @Test
+    fun `adapter unit test - 문자열 주소값이 2등분일 경우 2개의 정보를 가진 주소 객체를 생성한다`() {
+        val address = "제주특별자치도 한림읍"
+        val resolver = SimpleAddressResolver()
+
+        val shopAddress = resolver.resolveAddress(address)
+
+        shopAddress.cityCode shouldBe "1234567890"
+        shopAddress.coordinates.longitude shouldBe 127.0
+        shopAddress.coordinates.latitude shouldBe 40.0
+        shopAddress.address.region1DepthName shouldBe "제주특별자치도"
+        shopAddress.address.region2DepthName shouldBe "한림읍"
+        shopAddress.address.region3DepthName shouldBe ""
+        shopAddress.address.region4DepthName shouldBe ""
+    }
+
+    @Test
+    fun `adapter unit test - 문자열 주소값이 2등분 이하일 경우 예외를 발생한다`() {
+        val address = "제주특별자치도"
+        val resolver = SimpleAddressResolver()
+
+        shouldThrow<IllegalArgumentException> {
+            resolver.resolveAddress(address)
+        } shouldHaveMessage "주소 형식이 올바르지 않습니다."
+    }
+}

--- a/mealkitary-infrastructure/adapter-address-resolver/src/test/kotlin/SimpleAddressResolverTest.kt
+++ b/mealkitary-infrastructure/adapter-address-resolver/src/test/kotlin/SimpleAddressResolverTest.kt
@@ -22,7 +22,7 @@ class SimpleAddressResolverTest : AnnotationSpec() {
         shopAddress.address.region1DepthName shouldBe "서울특별시"
         shopAddress.address.region2DepthName shouldBe "강남구"
         shopAddress.address.region3DepthName shouldBe "역삼동"
-        shopAddress.address.region4DepthName shouldBe "논현로"
+        shopAddress.address.roadName shouldBe "논현로"
     }
 
     @Test
@@ -38,7 +38,7 @@ class SimpleAddressResolverTest : AnnotationSpec() {
         shopAddress.address.region1DepthName shouldBe "경기도"
         shopAddress.address.region2DepthName shouldBe "남양주시"
         shopAddress.address.region3DepthName shouldBe "다산동"
-        shopAddress.address.region4DepthName shouldBe ""
+        shopAddress.address.roadName shouldBe ""
     }
 
     @Test
@@ -54,7 +54,7 @@ class SimpleAddressResolverTest : AnnotationSpec() {
         shopAddress.address.region1DepthName shouldBe "제주특별자치도"
         shopAddress.address.region2DepthName shouldBe "한림읍"
         shopAddress.address.region3DepthName shouldBe ""
-        shopAddress.address.region4DepthName shouldBe ""
+        shopAddress.address.roadName shouldBe ""
     }
 
     @Test

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/data.sql
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/main/resources/data.sql
@@ -1,5 +1,5 @@
 insert into shop
-values (1, '123-12-12345', 'VALID', '집밥뚝딱 철산점');
+values (1, '경기도', '광명시', '철산동', '철산로', '1234567890', 30.03, 50.05, '123-12-12345', 'VALID', '집밥뚝딱 철산점');
 insert into product
 values (1, '부대찌개', 15800, 1);
 insert into product
@@ -17,7 +17,7 @@ values (1, '18:30');
 
 
 insert into shop
-values (2, '123-12-12345', 'VALID', '집밥뚝딱 안양점');
+values (2, '경기도', '안양시', '동안구', '경수대로', '1234567890', 30.03, 50.05, '123-12-12345', 'VALID', '집밥뚝딱 안양점');
 insert into product
 values (4, '비비고 만두', 3200, 2);
 insert into product
@@ -30,7 +30,7 @@ insert into reservable_time
 values (2, '19:30');
 
 insert into shop
-values (3, '123-12-12345', 'VALID', '집밥뚝딱 숭실대입구점');
+values (3, '서울시', '동작구', '상도동', '', '1234567890', 30.03, 50.05, '123-12-12345', 'VALID', '집밥뚝딱 숭실대입구점');
 insert into product
 values (7, '왕만두', 4900, 3);
 insert into product
@@ -48,7 +48,7 @@ values (3, '23:30');
 
 
 insert into shop
-values (4, '123-12-12345', 'VALID', '집밥뚝딱 다산점');
+values (4, '경기도', '남양주시', '다산동', '', '1234567890', 30.03, 50.05, '123-12-12345', 'VALID', '집밥뚝딱 다산점');
 insert into product
 values (10, '김치찌개', 15800, 4);
 insert into reservable_time

--- a/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/test/kotlin/com/mealkitary/PersistenceIntegrationTestSupport.kt
+++ b/mealkitary-infrastructure/adapter-persistence-spring-data-jpa/src/test/kotlin/com/mealkitary/PersistenceIntegrationTestSupport.kt
@@ -4,6 +4,7 @@ import com.mealkitary.reservation.application.service.AcceptReservationService
 import com.mealkitary.reservation.application.service.PayReservationService
 import com.mealkitary.reservation.application.service.RejectReservationService
 import com.mealkitary.shop.application.service.RegisterShopService
+import com.mealkitary.shop.domain.shop.factory.ShopFactory
 import com.ninjasquad.springmockk.MockkBean
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.extensions.spring.SpringExtension
@@ -36,4 +37,7 @@ abstract class PersistenceIntegrationTestSupport : AnnotationSpec() {
 
     @MockkBean
     private lateinit var registerShopService: RegisterShopService
+
+    @MockkBean
+    private lateinit var shopFactory: ShopFactory
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,8 @@ include(
     "mealkitary-infrastructure:adapter-paymentgateway-tosspayments",
     "mealkitary-infrastructure:adapter-firebase-notification",
     "mealkitary-infrastructure:business-registration-number-validator:adapter-open-api-brn-validator",
-    "mealkitary-infrastructure:business-registration-number-validator:adapter-simple-brn-validator"
+    "mealkitary-infrastructure:business-registration-number-validator:adapter-simple-brn-validator",
+    "mealkitary-infrastructure:adapter-address-resolver"
 )
 
 pluginManagement {
@@ -36,3 +37,5 @@ pluginManagement {
         }
     }
 }
+include("mealkitary-infrastructure:adapter-address-resolver")
+findProject(":mealkitary-infrastructure:adapter-address-resolver")?.name = "adapter-address-resolver"


### PR DESCRIPTION
**구현 요약**
- 가게 생성 시 주소를 함께 입력받도록 작성했습니다.
- 카카오 api 연동을 통해 세부 주소 정보를 받아오도록 수정할 예정입니다.
- 중복 파일이 생성되는 문제가 발생하여 api의 build.gradle에 중복 파일을 제거하도록 설정했습니다.

**연관 이슈**
#79 